### PR TITLE
chore: .claude gitignore 추가 및 리뷰 문서 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.claude

--- a/reviews/2026033013_리뷰.md
+++ b/reviews/2026033013_리뷰.md
@@ -1,0 +1,343 @@
+# 프로젝트 코드 리뷰
+
+> 리뷰 날짜: 2026-03-30
+> 대상: L'OcciShop 클론 프로젝트 (록시땅 쇼핑몰 클론)
+
+---
+
+## 1. 프로젝트 구조 살펴보기
+
+현재 프로젝트의 파일 구조는 이렇게 되어 있습니다:
+
+```
+loccishop/
+├── .github/
+│   └── PULL_REQUEST_TEMPLATE.md
+├── .gitignore
+├── eslint.config.js
+├── index.html
+├── package.json
+├── README.md                    ← (비어 있음)
+├── src/
+│   ├── assets/
+│   │   ├── icon/
+│   │   │   └── logo.svg
+│   │   └── images/
+│   │       └── .gitkeep
+│   ├── components/
+│   │   └── .gitkeep
+│   ├── css/
+│   │   └── style.css
+│   ├── js/
+│   │   └── main.js
+│   └── pages/
+│       └── .gitkeep
+└── vite.config.js
+```
+
+---
+
+## 2. 잘한 점
+
+### 체계적인 프로젝트 초기 세팅
+
+프로젝트 초기 구조가 정말 잘 잡혀 있어요! 처음부터 폴더를 역할별로 나누어 놓은 것이 인상적이에요.
+
+- `src/assets/` — 이미지, 아이콘 등 정적 파일
+- `src/components/` — 재사용할 컴포넌트
+- `src/pages/` — 개별 페이지
+- `src/css/` — 스타일시트
+- `src/js/` — 자바스크립트
+
+빈 폴더에 `.gitkeep` 파일을 넣어서 Git에 빈 폴더도 추적되게 한 것도 잘 알고 계시네요!
+
+### Tailwind CSS v4 + Vite 플러그인 구성
+
+```js
+// vite.config.js
+import tailwindcss from "@tailwindcss/vite";
+export default defineConfig({
+  plugins: [tailwindcss()],
+});
+```
+
+Tailwind CSS v4를 CDN이 아닌 **Vite 플러그인**으로 올바르게 설정했어요. CDN 방식보다 빌드 시 사용하지 않는 CSS를 자동으로 제거해주기 때문에 성능이 훨씬 좋아요. 최신 방식을 사용하고 있어서 훌륭합니다!
+
+### ESLint 설정이 꼼꼼해요
+
+```js
+rules: {
+  "no-unused-vars": "warn",
+  "prefer-const": "error",
+  eqeqeq: "error",
+  curly: "error",
+  "no-implicit-globals": "error",
+  "no-var": "error",
+}
+```
+
+ESLint 규칙을 단순히 기본값만 쓰지 않고, `eqeqeq` (===  강제), `no-var` (var 금지), `prefer-const` (const 우선) 같은 좋은 습관을 강제하는 규칙들을 직접 설정했어요. 특히 `no-implicit-globals`로 전역 변수 생성을 막은 건 실무에서도 중요한 규칙이에요. 주석으로 각 규칙의 의미를 적어둔 것도 아주 좋아요!
+
+또한 JS뿐 아니라 JSON, Markdown, CSS 파일까지 린팅 대상에 포함한 것도 세심해요.
+
+### HTML 기본 구조가 정확해요
+
+```html
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>L'OcciShop 클론 프로젝트</title>
+```
+
+- `<!DOCTYPE html>` 선언 있음
+- `lang="ko"` 설정 있음 (접근성과 SEO에 중요해요)
+- `charset="UTF-8"` 설정 있음
+- `viewport` 메타태그로 반응형 대비 완료
+
+이 네 가지는 HTML을 시작할 때 반드시 있어야 하는 것들인데, 빠짐없이 잘 넣어주셨어요!
+
+### Git 관련 설정이 좋아요
+
+- `.gitignore`에 `node_modules`, `dist`, 에디터 설정 파일 등이 잘 포함되어 있어요
+- PR 템플릿(`PULL_REQUEST_TEMPLATE.md`)까지 준비해둔 것은 팀 협업을 미리 생각한 것이라 정말 좋습니다
+
+---
+
+## 3. 개선하면 좋을 점
+
+### 3-1. CSS가 두 번 로딩되고 있어요 (중요도: 높음)
+
+**현재 상태:**
+
+`index.html`에서 CSS를 직접 불러오고 있어요:
+```html
+<!-- index.html 7번째 줄 -->
+<link rel="stylesheet" href="/src/css/style.css" />
+```
+
+동시에 `main.js`에서도 같은 CSS를 import하고 있어요:
+```js
+// src/js/main.js 1번째 줄
+import "../css/style.css";
+```
+
+**왜 개선하면 좋을까?**
+
+같은 CSS 파일이 두 곳에서 로딩되면, 브라우저가 같은 스타일을 두 번 처리하게 될 수 있어요. Vite 프로젝트에서는 **JS에서 CSS를 import하는 방식** 하나만 사용하는 것이 권장돼요. Vite가 자동으로 `<style>` 태그를 만들어서 페이지에 넣어주거든요.
+
+**추천:** HTML의 `<link>` 태그를 제거하고, JS에서만 CSS를 import하세요.
+
+```html
+<!-- index.html: <link rel="stylesheet"> 줄을 삭제 -->
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>L'OcciShop 클론 프로젝트</title>
+  <!-- <link> 태그 없이도 main.js가 CSS를 불러와요 -->
+</head>
+```
+
+---
+
+### 3-2. 시맨틱 HTML 태그를 사용하면 더 좋아요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- index.html 11번째 줄 -->
+<div id="header"></div>
+
+<!-- index.html 20번째 줄 -->
+<div id="footer"></div>
+```
+
+**왜 개선하면 좋을까?**
+
+"시맨틱 태그"란 **의미를 가진 태그**를 말해요. `<div>`는 "그냥 상자"인데, `<header>`는 "이건 머리말이야"라고 브라우저와 스크린 리더(시각 장애인용 도구)에게 알려줘요. 검색엔진(구글 등)도 시맨틱 태그를 보고 페이지 구조를 더 잘 이해해요.
+
+**추천:** `<div>` 대신 의미에 맞는 시맨틱 태그를 사용하세요.
+
+```html
+<!-- 수정 전 -->
+<div id="header"></div>
+<div id="footer"></div>
+
+<!-- 수정 후 -->
+<header id="header"></header>
+<footer id="footer"></footer>
+```
+
+`id`는 그대로 유지하면 되니까 JS 로직에는 영향이 없어요!
+
+---
+
+### 3-3. 멀티 페이지 빌드 설정이 필요해요 (중요도: 중간)
+
+**현재 상태:**
+
+`src/pages/` 디렉토리가 준비되어 있지만, `vite.config.js`에 멀티 페이지 빌드 설정이 없어요.
+
+```js
+// vite.config.js — 현재
+export default defineConfig({
+  plugins: [tailwindcss()],
+  root: ".",
+  server: { port: 5173, open: true },
+});
+```
+
+**왜 개선하면 좋을까?**
+
+Vite는 기본적으로 루트의 `index.html` 하나만 빌드해요. 나중에 `src/pages/` 에 상품 목록 페이지, 상세 페이지 등을 추가하더라도 `vite build` 명령어가 그 페이지들을 포함하지 않게 돼요. 지금 설정해두면 나중에 페이지를 추가할 때 바로 동작해요.
+
+**추천:** 페이지를 추가할 때 `vite.config.js`에 해당 페이지를 등록해주세요. 예를 들어 `src/pages/product.html`을 만든다면:
+
+```js
+// vite.config.js — 페이지 추가 시 예시
+import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [tailwindcss()],
+  root: ".",
+  server: { port: 5173, open: true },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        product: resolve(__dirname, "src/pages/product.html"),
+      },
+    },
+  },
+});
+```
+
+지금 당장은 페이지가 `index.html` 하나뿐이라 급하지 않지만, 새 페이지를 만들 때 이 설정이 필요하다는 걸 기억해두세요!
+
+---
+
+### 3-4. `main.js`에 기본 코드가 거의 없어요 (중요도: 낮음)
+
+**현재 상태:**
+
+```js
+// src/js/main.js
+import "../css/style.css";
+```
+
+**왜 개선하면 좋을까?**
+
+지금은 CSS import만 있어서 괜찮지만, 프로젝트를 진행하면서 헤더/푸터를 JS로 불러오겠다는 계획이 HTML 주석에 있어요:
+
+```html
+<!-- 헤더 불러오기 (JS로 처리할 예정) -->
+<div id="header"></div>
+```
+
+이 계획을 구현하려면 `main.js`에서 컴포넌트를 불러와서 DOM에 넣는 코드가 필요해요.
+
+**추천:** 다음 단계로 헤더/푸터 컴포넌트를 만들어보는 것을 추천해요!
+
+```js
+// src/js/main.js — 향후 구현 예시
+import "../css/style.css";
+
+// 헤더 컴포넌트 로딩
+const headerEl = document.getElementById("header");
+if (headerEl) {
+  headerEl.innerHTML = `
+    <nav class="bg-white shadow-md p-4">
+      <h1 class="text-xl font-bold">L'OcciShop</h1>
+    </nav>
+  `;
+}
+```
+
+---
+
+### 3-5. `<meta name="description">` 태그가 없어요 (중요도: 낮음)
+
+**현재 상태:**
+
+```html
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>L'OcciShop 클론 프로젝트</title>
+</head>
+```
+
+**왜 개선하면 좋을까?**
+
+`<meta name="description">`은 검색엔진(구글)에서 이 페이지가 무엇에 대한 것인지 설명하는 태그예요. 검색 결과에서 페이지 제목 아래에 나오는 설명 문구가 바로 이 태그의 내용이에요. 필수는 아니지만 웹 개발에서 좋은 습관이에요.
+
+**추천:**
+
+```html
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="L'Occitane 쇼핑몰 클론 프로젝트 - 프론트엔드 부트캠프" />
+  <title>L'OcciShop 클론 프로젝트</title>
+</head>
+```
+
+---
+
+### 3-6. favicon(파비콘)이 설정되어 있지 않아요 (중요도: 낮음)
+
+**현재 상태:**
+
+`index.html`에 `<link rel="icon">` 태그가 없어요.
+
+**왜 개선하면 좋을까?**
+
+파비콘은 브라우저 탭에 표시되는 작은 아이콘이에요. 파비콘이 없으면 브라우저가 기본 아이콘을 보여주고, 개발자 도구 콘솔에 `favicon.ico` 404 에러가 뜰 수도 있어요. `src/assets/icon/logo.svg` 파일이 이미 있으니 이걸 활용하면 돼요!
+
+**추천:**
+
+```html
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" href="/src/assets/icon/logo.svg" type="image/svg+xml" />
+  <title>L'OcciShop 클론 프로젝트</title>
+</head>
+```
+
+---
+
+## 4. 파일별 요약
+
+| 파일 | 완성도 | 주요 피드백 |
+|------|--------|-------------|
+| `index.html` | 70% | 기본 구조 좋음. CSS 이중 로딩 수정 필요, 시맨틱 태그 사용 권장 |
+| `src/css/style.css` | 100% | Tailwind v4 import 방식 정확 |
+| `src/js/main.js` | 50% | CSS import만 있음. 향후 컴포넌트 로딩 코드 추가 필요 |
+| `vite.config.js` | 80% | 기본 설정 좋음. 멀티 페이지 빌드 설정은 페이지 추가 시 필요 |
+| `eslint.config.js` | 95% | 꼼꼼하고 훌륭한 설정 |
+| `.gitignore` | 90% | 필요한 항목 잘 포함 |
+| `package.json` | 90% | 기술 스택 적절, 스크립트 설정 좋음 |
+
+---
+
+## 5. 다음 단계 제안
+
+1. **CSS 이중 로딩 수정** — `index.html`의 `<link rel="stylesheet">` 제거 (1분이면 끝!)
+2. **시맨틱 태그 적용** — `<div id="header">`를 `<header id="header">`로 변경
+3. **헤더/푸터 컴포넌트 만들기** — `src/components/`에 헤더, 푸터 HTML 구조 작성
+4. **메인 페이지 콘텐츠 채우기** — 실제 쇼핑몰 레이아웃 구현 시작
+5. **상품 목록 페이지 추가** — `src/pages/`에 새 페이지 생성
+
+---
+
+## 6. 마무리
+
+프로젝트 초기 세팅이 정말 탄탄해요! Vite + Tailwind CSS v4 조합, 꼼꼼한 ESLint 설정, 체계적인 폴더 구조까지 — 이 정도 세팅을 해놓으면 앞으로 기능을 추가할 때 훨씬 수월해질 거예요.
+
+지금은 아직 시작 단계라 코드가 적지만, 기초 공사를 이렇게 잘 해놓은 것 자체가 아주 중요해요. 건물도 기초가 튼튼해야 높이 올릴 수 있잖아요!
+
+CSS 이중 로딩만 빠르게 수정하고, 헤더/푸터 컴포넌트부터 하나씩 만들어보세요. 화이팅입니다!

--- a/reviews/2026033013_리뷰_해결.md
+++ b/reviews/2026033013_리뷰_해결.md
@@ -1,0 +1,257 @@
+# 리뷰 해결 가이드
+
+> 리뷰 날짜: 2026-03-30
+> 대상: L'OcciShop 클론 프로젝트 (록시땅 쇼핑몰 클론)
+> 원본 리뷰: [2026033013_리뷰.md](./2026033013_리뷰.md)
+
+---
+
+## 3-1. CSS가 두 번 로딩되고 있어요 (중요도: 높음)
+
+### 문제
+
+`index.html` 7번째 줄에서 `<link>` 태그로 CSS를 불러오고, `src/js/main.js` 1번째 줄에서도 `import`로 같은 CSS를 불러오고 있어요. 같은 파일이 두 번 로딩돼요.
+
+### 해결 방법
+
+**Step 1.** `index.html`에서 CSS `<link>` 태그를 삭제하세요.
+
+```html
+<!-- 수정 전 (index.html 5~8번째 줄) -->
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>L'OcciShop 클론 프로젝트</title>
+  <link rel="stylesheet" href="/src/css/style.css" />
+</head>
+
+<!-- 수정 후 -->
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>L'OcciShop 클론 프로젝트</title>
+</head>
+```
+
+**Step 2.** `src/js/main.js`의 CSS import는 그대로 유지하세요.
+
+```js
+// src/js/main.js — 이 줄은 그대로 두세요!
+import "../css/style.css";
+```
+
+Vite는 JS에서 import한 CSS를 자동으로 `<style>` 태그로 변환해서 페이지에 넣어줘요. 그래서 HTML에서 따로 `<link>`로 불러올 필요가 없어요.
+
+> **쉽게 말하면:** 택배(CSS)를 문 앞(HTML)에서 한 번, 택배함(JS)에서 한 번 — 두 번 받고 있었어요. 한 곳에서만 받으면 돼요!
+
+---
+
+## 3-2. 시맨틱 HTML 태그를 사용하면 더 좋아요 (중요도: 중간)
+
+### 문제
+
+`index.html` 11번째 줄과 20번째 줄에서 헤더와 푸터 영역에 의미 없는 `<div>` 태그를 사용하고 있어요.
+
+### 해결 방법
+
+**Step 1.** `index.html`에서 `<div id="header">`를 `<header>`로 변경하세요.
+
+```html
+<!-- 수정 전 (index.html 11번째 줄) -->
+<div id="header"></div>
+
+<!-- 수정 후 -->
+<header id="header"></header>
+```
+
+**Step 2.** `<div id="footer">`를 `<footer>`로 변경하세요.
+
+```html
+<!-- 수정 전 (index.html 20번째 줄) -->
+<div id="footer"></div>
+
+<!-- 수정 후 -->
+<footer id="footer"></footer>
+```
+
+`id` 속성은 그대로 두기 때문에 나중에 `document.getElementById("header")`로 접근하는 JS 코드도 변경 없이 동작해요.
+
+> **쉽게 말하면:** 방에 이름표를 붙이는 거예요. "방1"이라고 적는 것보다 "주방", "거실"이라고 적으면 누구나 무슨 방인지 바로 알 수 있잖아요. 시맨틱 태그가 바로 그 이름표예요!
+
+---
+
+## 3-3. 멀티 페이지 빌드 설정이 필요해요 (중요도: 중간)
+
+### 문제
+
+`src/pages/` 디렉토리가 있지만, `vite.config.js`에 멀티 페이지 빌드 설정이 없어서 `index.html` 외의 페이지는 빌드에 포함되지 않아요.
+
+### 해결 방법
+
+이 항목은 **새 페이지를 추가할 때** 적용하면 돼요. 지금은 `index.html`만 있으니 급하지 않아요!
+
+**페이지를 추가할 때 따라하세요:**
+
+**Step 1.** 새 HTML 페이지를 만들어요 (예: `src/pages/product.html`).
+
+**Step 2.** `vite.config.js`를 수정해요.
+
+```js
+// 수정 전 (vite.config.js)
+import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [tailwindcss()],
+  root: ".",
+  server: {
+    port: 5173,
+    open: true,
+  },
+});
+
+// 수정 후
+import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [tailwindcss()],
+  root: ".",
+  server: {
+    port: 5173,
+    open: true,
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        product: resolve(__dirname, "src/pages/product.html"),
+        // 새 페이지를 추가할 때마다 여기에 한 줄씩 추가하면 돼요
+      },
+    },
+  },
+});
+```
+
+> **쉽게 말하면:** Vite한테 "이 프로젝트에 페이지가 여러 개야, 여기 있는 것들 다 빌드해줘!"라고 알려주는 거예요. 안 알려주면 첫 페이지(index.html)만 빌드해요.
+
+---
+
+## 3-4. `main.js`에 기본 코드가 거의 없어요 (중요도: 낮음)
+
+### 문제
+
+`src/js/main.js`에 CSS import 외에 아무 코드가 없어서, HTML 주석에 적힌 "헤더/푸터를 JS로 처리할 예정"이라는 계획이 아직 구현되지 않았어요.
+
+### 해결 방법
+
+**Step 1.** `src/components/` 디렉토리에 헤더 컴포넌트 함수를 만들어보세요.
+
+먼저 `src/components/header.js` 파일을 새로 만드세요:
+
+```js
+// src/components/header.js — 새 파일
+export function createHeader() {
+  return `
+    <nav class="bg-white shadow-md">
+      <div class="container mx-auto px-4 py-3 flex items-center justify-between">
+        <a href="/" class="text-xl font-bold">L'OcciShop</a>
+        <ul class="flex gap-6">
+          <li><a href="/" class="hover:text-blue-600">홈</a></li>
+          <li><a href="#" class="hover:text-blue-600">상품</a></li>
+        </ul>
+      </div>
+    </nav>
+  `;
+}
+```
+
+**Step 2.** `src/js/main.js`에서 이 컴포넌트를 불러와서 사용하세요.
+
+```js
+// 수정 전 (src/js/main.js)
+import "../css/style.css";
+
+// 수정 후
+import "../css/style.css";
+import { createHeader } from "../components/header.js";
+
+const headerEl = document.getElementById("header");
+if (headerEl) {
+  headerEl.innerHTML = createHeader();
+}
+```
+
+`if (headerEl)` 체크를 해주는 이유는, 혹시 HTML에 `id="header"` 요소가 없는 페이지에서도 에러 없이 동작하게 하려는 거예요.
+
+> **쉽게 말하면:** 레고 블록(컴포넌트)을 따로 만들어두고, 필요한 곳에 끼워 넣는 방식이에요. 이렇게 하면 모든 페이지에서 같은 헤더를 재사용할 수 있어요!
+
+---
+
+## 3-5. `<meta name="description">` 태그가 없어요 (중요도: 낮음)
+
+### 문제
+
+`index.html`의 `<head>` 안에 페이지 설명 메타 태그가 없어요.
+
+### 해결 방법
+
+**Step 1.** `index.html`의 `<head>` 안에 아래 한 줄을 추가하세요.
+
+```html
+<!-- 수정 전 (index.html 4~8번째 줄) -->
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>L'OcciShop 클론 프로젝트</title>
+</head>
+
+<!-- 수정 후 -->
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="L'Occitane 쇼핑몰 클론 프로젝트 - 프론트엔드 부트캠프" />
+  <title>L'OcciShop 클론 프로젝트</title>
+</head>
+```
+
+> **쉽게 말하면:** 구글에서 검색했을 때 페이지 제목 아래에 나오는 설명글이에요. 책의 뒷표지 소개글 같은 거죠!
+
+---
+
+## 3-6. favicon(파비콘)이 설정되어 있지 않아요 (중요도: 낮음)
+
+### 문제
+
+`index.html`에 파비콘 설정이 없어서 브라우저 탭에 기본 아이콘이 표시돼요.
+
+### 해결 방법
+
+**Step 1.** `index.html`의 `<head>` 안에 아래 한 줄을 추가하세요. 이미 있는 `logo.svg`를 활용해요!
+
+```html
+<!-- 수정 전 (index.html <head> 안) -->
+<title>L'OcciShop 클론 프로젝트</title>
+
+<!-- 수정 후 -->
+<link rel="icon" href="/src/assets/icon/logo.svg" type="image/svg+xml" />
+<title>L'OcciShop 클론 프로젝트</title>
+```
+
+> **쉽게 말하면:** 브라우저 탭에 나오는 작은 로고예요. 이미 로고 파일이 있으니 연결만 해주면 돼요!
+
+---
+
+## 수정 우선순위 체크리스트
+
+| 순서 | 항목 | 난이도 | 예상 시간 |
+|------|------|--------|-----------|
+| 1 | 3-1. CSS 이중 로딩 수정 | 쉬움 | 1분 |
+| 2 | 3-2. 시맨틱 태그 적용 | 쉬움 | 2분 |
+| 3 | 3-6. 파비콘 설정 | 쉬움 | 1분 |
+| 4 | 3-5. description 메타태그 추가 | 쉬움 | 1분 |
+| 5 | 3-4. 헤더 컴포넌트 만들기 | 보통 | 15분 |
+| 6 | 3-3. 멀티 페이지 빌드 설정 | 보통 | 페이지 추가 시 |
+
+> 1~4번은 5분이면 모두 끝나요! 쉬운 것부터 하나씩 체크해 나가면 금방이에요. 처음 세팅을 이렇게 잘 해놓으셨으니, 앞으로 기능 구현도 잘 해내실 거예요. 파이팅!


### PR DESCRIPTION
## Summary
- `.gitignore`에 `.claude` 디렉토리 추가
- `reviews/` 디렉토리에 코드 리뷰 문서 및 해결 가이드 추가

## 리뷰 결과 요약

**분석 파일:** 7개 | **잘한 점:** 5개 | **개선 항목:** 6개 (높음 1 / 중간 2 / 낮음 3)

### 잘한 점
- 체계적인 프로젝트 초기 구조 (assets, components, pages, css, js 분리)
- Tailwind CSS v4 + Vite 플러그인 올바른 구성
- ESLint 규칙 꼼꼼한 설정 (eqeqeq, no-var, prefer-const 등)
- HTML 기본 구조 정확 (DOCTYPE, lang, charset, viewport)
- Git 설정 (.gitignore, PR 템플릿) 잘 준비

### 개선 항목

| # | 항목 | 중요도 |
|---|------|--------|
| 3-1 | **CSS 이중 로딩** — `index.html`의 `<link>`와 `main.js`의 `import`가 같은 CSS를 중복 로딩 | 높음 |
| 3-2 | **시맨틱 HTML 태그** — `<div id="header/footer">` → `<header>/<footer>` | 중간 |
| 3-3 | **멀티 페이지 빌드 설정** — `src/pages/` 존재하나 `vite.config.js`에 빌드 설정 없음 | 중간 |
| 3-4 | **`main.js` 기본 코드** — CSS import만 있고 헤더/푸터 컴포넌트 로딩 미구현 | 낮음 |
| 3-5 | **`<meta description>` 누락** — SEO용 메타 태그 없음 | 낮음 |
| 3-6 | **favicon 미설정** — `logo.svg` 있지만 연결 안 됨 | 낮음 |

### 파일별 완성도

| 파일 | 완성도 |
|------|--------|
| `eslint.config.js` | 95% |
| `package.json` | 90% |
| `.gitignore` | 90% |
| `vite.config.js` | 80% |
| `index.html` | 70% |
| `src/js/main.js` | 50% |
| `src/css/style.css` | 100% |

> 상세 내용은 `reviews/2026033013_리뷰.md`, 해결 방법은 `reviews/2026033013_리뷰_해결.md` 참고

## Test plan
- [x] `.gitignore` 변경 확인
- [x] 리뷰 문서 파일 생성 확인
- [x] 리뷰 해결 가이드 파일 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)