### PR TITLE
docs: 3차 코드 리뷰 문서 추가

### DIFF
--- a/docs/2026040614_리뷰.md
+++ b/docs/2026040614_리뷰.md
@@ -1,0 +1,765 @@
+# 프로젝트 코드 리뷰
+
+> 리뷰 날짜: 2026-04-06
+> 대상: L'OcciShop 클론 프로젝트 (록시땅 쇼핑몰 클론)
+> 이전 리뷰: [2026040314_리뷰.md](./2026040314_리뷰.md)
+
+---
+
+## 0. 이번 리뷰 범위
+
+이번 리뷰는 이전 리뷰(2026040314) 이후 **develop 브랜치에 머지된 변경 파일**을 대상으로 합니다. 32개 커밋이 머지되어 프로젝트가 크게 성장했어요!
+
+**변경/추가된 파일:**
+- `index.html` — 시맨틱 태그 적용, `<body>` 클래스 유지
+- `vite.config.js` — 멀티 페이지 빌드 설정 추가 (경로 오류 있음)
+- `src/styles/style.css` — `src/css/style.css`에서 이동, 테마 변수 추가
+- `src/js/main.js` — CSS import 경로 변경
+- `src/pages/login/index.html` — 로그인 페이지 (feature 브랜치에서 머지)
+- `src/pages/signup/index.html` — 회원가입 페이지 (신규)
+- `src/pages/product/detail/index.html` — 상품 상세 페이지 (신규)
+- `src/pages/product/detail/index.js` — 상품 상세 JS (신규)
+- `src/pages/product/detail/components/detail-main.html` — 상품 메인 영역 (신규)
+- `src/pages/product/detail/components/detail-info.html` — 상품 정보 영역 (신규)
+- `src/components/ui/badge.js` — 배지 UI 컴포넌트 (신규)
+- `src/components/ui/button.js` — 버튼 UI 컴포넌트 (신규)
+- `src/components/ui/drawer.js` — 드로어 UI 컴포넌트 (신규)
+- `src/components/ui/product-card.js` — 상품 카드 UI 컴포넌트 (신규)
+- `src/components/ui/tag.js` — 태그 UI 컴포넌트 (신규)
+- `src/assets/icon/*.svg` — 아이콘 9개 추가
+- `.gitignore` — 변경됨
+
+**이전 리뷰 해결된 항목:**
+잘했어요! 아래 항목들은 이전 리뷰 이후 잘 수정되었어요.
+- ~~3-8. 빈 컴포넌트 파일 (header.js, footer.js)~~ — `.gitkeep` 파일이 제거되고 실제 UI 컴포넌트(badge, button, drawer, tag, product-card)가 구현되었어요! 해결 완료!
+- ~~3-9. 아포스트로피 오타~~ — `<title>` 태그에서 `L'OcciShop`으로 올바르게 수정되었어요! 해결 완료!
+
+**이전 리뷰 미해결 항목:**
+아래 항목들은 이전 리뷰에서 지적되었지만 아직 수정되지 않았어요.
+- 3-1. `--color-empress: #7E717` 색상 코드 오류 → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-1-stylecss--잘못된-색상-코드가-있어요-중요도-높음)
+- 3-2. `--color--grey-99` 하이픈 두 개 → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-2-stylecss--css-변수-이름에-하이픈이-두-개예요-중요도-높음)
+- 3-3. 중복 색상 변수 (`woody-brown` = `brand-woody`) → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-3-stylecss--같은-색상값이-다른-이름으로-중복돼요-중요도-중간)
+- 3-4. 로그인 모달 모바일 반응형 (`w-200` 고정) → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-4-로그인-페이지--모바일에서-화면이-깨질-수-있어요-중요도-중간)
+- 3-5. 로그인 폼 `<form action="">` → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-5-로그인-페이지--form-action이-비어-있어요-중요도-중간)
+
+---
+
+## 1. 프로젝트 구조 살펴보기
+
+```
+loccishop/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug_report.md
+│   │   └── feature_request.md
+│   └── PULL_REQUEST_TEMPLATE.md
+├── .gitignore                          ← 변경됨 (문제 있음!)
+├── docs/
+│   └── api/                            ← API 문서 11개
+├── eslint.config.js
+├── index.html                          ← 시맨틱 태그 적용됨
+├── package.json
+├── README.md
+├── reviews/
+├── src/
+│   ├── assets/
+│   │   ├── icon/
+│   │   │   ├── cart.svg               ← NEW
+│   │   │   ├── check.svg              ← NEW
+│   │   │   ├── error.svg              ← NEW
+│   │   │   ├── heart.svg              ← NEW
+│   │   │   ├── heart-empty.svg        ← NEW
+│   │   │   ├── login_xBtn.svg         ← NEW
+│   │   │   ├── logo.svg
+│   │   │   ├── passwordEye.svg        ← NEW
+│   │   │   ├── star.svg               ← NEW
+│   │   │   └── star-empty.svg         ← NEW
+│   │   └── images/
+│   │       └── product1_0~7.webp      ← NEW (상품 이미지 8개)
+│   ├── components/
+│   │   └── ui/
+│   │       ├── badge.js               ← NEW
+│   │       ├── button.js              ← NEW
+│   │       ├── drawer.js              ← NEW
+│   │       ├── product-card.js        ← NEW
+│   │       └── tag.js                 ← NEW
+│   ├── js/
+│   │   └── main.js                    ← import 경로 변경
+│   ├── pages/
+│   │   ├── login/
+│   │   │   └── index.html             ← NEW
+│   │   ├── product/
+│   │   │   └── detail/
+│   │   │       ├── components/
+│   │   │       │   ├── detail-info.html   ← NEW
+│   │   │       │   └── detail-main.html   ← NEW
+│   │   │       ├── index.html         ← NEW
+│   │   │       └── index.js           ← NEW
+│   │   └── signup/
+│   │       └── index.html             ← NEW
+│   └── styles/
+│       └── style.css                  ← src/css/ 에서 이동
+└── vite.config.js                     ← 멀티 페이지 설정 추가
+```
+
+이전 리뷰 때와 비교하면 프로젝트 구조가 훨씬 체계적으로 발전했어요! 특히 `src/components/ui/` 디렉토리에 재사용 가능한 UI 컴포넌트들을 모아둔 것이 인상적이에요.
+
+---
+
+## 2. 잘한 점
+
+### UI 컴포넌트 설계가 훌륭해요! (응집도 높음)
+
+`src/components/ui/` 디렉토리의 컴포넌트들이 **각자 하나의 역할만** 담당하고 있어요. 이것을 **높은 응집도(High Cohesion)**라고 해요 — "한 모듈이 하나의 책임만 가진다"는 뜻이에요.
+
+```js
+// badge.js — 배지만 만들어요
+export function createBadge({ type = "NEW" } = {}) { ... }
+
+// button.js — 버튼만 만들어요
+export function createButton({ text, variant, size, fullWidth } = {}) { ... }
+
+// drawer.js — 드로어만 만들어요
+export function createDrawer({ title, position } = {}) { ... }
+```
+
+각 컴포넌트가 **props(설정값)**를 받아서 DOM 요소를 반환하는 동일한 패턴을 따르고 있어요. 이렇게 하면 다른 페이지에서도 쉽게 재사용할 수 있어요!
+
+### button.js의 variant/size 패턴이 아주 좋아요!
+
+```js
+const variantClass = {
+  primary: "min-w-16 rounded bg-woody-brown ...",
+  outline: "border border-empress rounded-sm ...",
+};
+
+const sizeClass = {
+  sm: "px-4 py-2.5 text-sm",
+  md: "py-4 text-sm",
+};
+```
+
+스타일 변형(variant)과 크기(size)를 **객체로 분리**해서 관리하는 것은 실무에서도 많이 사용하는 패턴이에요. Tailwind + JavaScript 조합의 모범 사례입니다!
+
+### drawer.js의 애니메이션 처리가 세련돼요!
+
+```js
+function open() {
+  document.body.append(overlay, drawer);
+  requestAnimationFrame(() => {
+    overlay.classList.replace("opacity-0", "opacity-100");
+    drawer.classList.replace("translate-x-full", "translate-x-0");
+  });
+  document.body.style.overflow = "hidden";
+}
+```
+
+`requestAnimationFrame`을 사용해서 애니메이션을 부드럽게 처리하고, `document.body.style.overflow = "hidden"`으로 배경 스크롤을 막는 것까지 신경 쓴 것이 좋아요!
+
+### 상품 상세 페이지의 HTML 시맨틱이 좋아요!
+
+```html
+<article class="content-wrapper ...">
+  <figure id="product-gallery">        <!-- 이미지 영역 -->
+  <section id="product-main">          <!-- 상품 정보 영역 -->
+    <header>                            <!-- 상품명, 가격 -->
+```
+
+`<article>`, `<figure>`, `<section>`, `<header>` 같은 시맨틱 태그를 적절하게 사용했어요. 검색 엔진과 스크린리더가 페이지 구조를 잘 이해할 수 있어요!
+
+### ESLint 설정이 탄탄해요!
+
+```js
+rules: {
+  eqeqeq: "error",             // === 사용 강제
+  "prefer-const": "error",     // const 강제
+  "no-var": "error",           // var 금지
+  "no-implicit-globals": "error", // 전역 변수 금지
+}
+```
+
+`===` 강제, `var` 금지, 전역 변수 금지 — 초보자가 흔히 실수하는 부분을 ESLint 규칙으로 미리 잡고 있어요. 아주 좋은 방어 장치에요!
+
+### 회원가입 폼의 접근성이 좋아요!
+
+```html
+<label for="userId" class="text-[14px] font-medium leading-5">아이디*</label>
+<input type="text" id="userId" name="userId" required />
+```
+
+모든 입력 필드에 `<label>`과 `<input>`이 `for`/`id`로 올바르게 연결되어 있어요. `required` 속성도 잘 적용했어요.
+
+### 상품 상세 페이지의 컴포넌트 분리가 좋아요!
+
+```
+src/pages/product/detail/
+├── components/
+│   ├── detail-main.html    ← 메인 영역 (이미지 + 기본 정보)
+│   └── detail-info.html    ← 상세 정보 영역 (설명 + 버튼들)
+├── index.html              ← 페이지 껍데기
+└── index.js                ← 로직 담당
+```
+
+HTML을 `components/` 폴더로 분리하고 JS에서 `fetch()`로 불러오는 구조가 깔끔해요. 화면(HTML)과 동작(JS)을 분리하려는 좋은 시도예요!
+
+---
+
+## 3. 개선하면 좋을 점
+
+### 3-1. `.gitignore`에서 `package.json`과 `package-lock.json`을 제외하고 있어요 (중요도: 높음)
+
+**현재 상태:**
+
+```gitignore
+# .gitignore 27~28번째 줄
+packge.json
+package-lock.json
+```
+
+**왜 개선하면 좋을까?**
+
+`package.json`은 프로젝트의 **설계도**예요! 어떤 라이브러리를 쓰는지, 어떤 명령어를 쓸 수 있는지 다 적혀 있어요. `package-lock.json`은 **정확한 버전 기록**이에요. 이 두 파일을 `.gitignore`에 넣으면:
+
+- 새 팀원이 `git clone`한 후 `npm install`을 실행할 수 없어요
+- 팀원마다 다른 버전의 라이브러리를 설치하게 돼요
+- 빌드가 안 되거나 에러가 나는 원인이 될 수 있어요
+
+게다가 `packge.json`은 오타예요 (`package`의 `a`가 빠졌어요). 하지만 오타 덕분에 실제로 `package.json`은 추적되고 있긴 해요. `package-lock.json`은 정확히 적혀 있어서 **진짜로 Git 추적에서 제외되고 있어요!**
+
+**추천:**
+
+```gitignore
+# 수정 전
+packge.json
+package-lock.json
+
+# 수정 후 — 이 두 줄을 삭제하세요!
+# (package.json과 package-lock.json은 반드시 Git으로 관리해야 해요)
+```
+
+---
+
+### 3-2. `vite.config.js`의 빌드 경로가 실제 파일과 달라요 (중요도: 높음)
+
+**현재 상태:**
+
+```js
+// vite.config.js 14~15번째 줄
+build: {
+  rollupOptions: {
+    input: {
+      main: resolve(__dirname, "index.html"),
+      productDetail: resolve(__dirname, "src/pages/product-detail.html"),  // ← 이 경로!
+    },
+  },
+},
+```
+
+**왜 개선하면 좋을까?**
+
+`src/pages/product-detail.html`이라는 파일은 존재하지 않아요! 실제 파일은 `src/pages/product/detail/index.html`에 있어요. 이렇게 되면 `npm run build`(배포용 빌드)를 실행할 때 **에러가 나서 배포가 안 돼요**.
+
+또한 로그인 페이지(`src/pages/login/index.html`)와 회원가입 페이지(`src/pages/signup/index.html`)도 빌드 설정에 빠져 있어요.
+
+**추천:**
+
+```js
+// 수정 전
+input: {
+  main: resolve(__dirname, "index.html"),
+  productDetail: resolve(__dirname, "src/pages/product-detail.html"),
+},
+
+// 수정 후 — 실제 파일 경로에 맞추고, 모든 페이지 추가
+input: {
+  main: resolve(__dirname, "index.html"),
+  login: resolve(__dirname, "src/pages/login/index.html"),
+  signup: resolve(__dirname, "src/pages/signup/index.html"),
+  productDetail: resolve(__dirname, "src/pages/product/detail/index.html"),
+},
+```
+
+---
+
+### 3-3. `detail-info.html`에 큰따옴표가 두 번 들어갔어요 (중요도: 높음)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/product/detail/components/detail-info.html 16~17번째 줄 -->
+<button
+  id="ingredients"
+  class="flex justify-between items-center ... bg-merino hover:bg-cararra""
+>                                                                        ^^
+                                                              여기 큰따옴표가 두 개!
+```
+
+같은 문제가 22~23번째 줄(`productDisclosure` 버튼)에도 있어요.
+
+**왜 개선하면 좋을까?**
+
+HTML에서 속성값은 `"..."`로 감싸야 하는데, `""`(큰따옴표 두 개)로 끝나면 브라우저가 혼란스러워해요. 지금은 브라우저가 알아서 처리해주지만, **HTML 유효성 검사(validation)에서 오류**로 잡히고, 나중에 예상치 못한 렌더링 문제가 생길 수 있어요.
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<button
+  id="ingredients"
+  class="flex justify-between ... bg-merino hover:bg-cararra""
+>
+
+<!-- 수정 후 — 맨 끝 큰따옴표 하나 제거 -->
+<button
+  id="ingredients"
+  class="flex justify-between ... bg-merino hover:bg-cararra"
+>
+```
+
+`productDisclosure` 버튼(22번째 줄)도 같은 방식으로 수정하세요.
+
+---
+
+### 3-4. 로그인 버튼의 클래스명 `bg--woody-brown`이 동작하지 않아요 (중요도: 높음)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/login/index.html 97번째 줄 -->
+<button
+  type="submit"
+  class="w-60 h-10 bg--woody-brown text-white-solid ..."
+>                   ^^
+          하이픈이 두 개! bg--woody-brown
+```
+
+**왜 개선하면 좋을까?**
+
+Tailwind CSS에서 `bg-woody-brown`(하이픈 1개)은 `--color-woody-brown` 색상을 배경에 적용해요. 하지만 `bg--woody-brown`(하이픈 2개)은 **존재하지 않는 클래스**여서 배경색이 안 나와요. 로그인 버튼이 **배경색 없이 하얀색**으로 보일 거예요!
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<button class="w-60 h-10 bg--woody-brown text-white-solid ...">
+
+<!-- 수정 후 — 하이픈 하나로 수정 -->
+<button class="w-60 h-10 bg-woody-brown text-white-solid ...">
+```
+
+---
+
+### 3-5. 상품 이미지에 `alt` 속성이 비어 있어요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/product/detail/components/detail-main.html -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="" />
+<!-- ... 총 8개 이미지 모두 alt="" -->
+```
+
+별점 아이콘도 마찬가지예요:
+```html
+<img src="/src/assets/icon/star.svg" />  <!-- alt 속성 자체가 없음 -->
+```
+
+**왜 개선하면 좋을까?**
+
+`alt` 속성은 **접근성(Accessibility)**의 핵심이에요:
+- 시각장애인이 스크린리더를 사용할 때 이미지 내용을 음성으로 읽어줘요
+- 이미지 로딩에 실패했을 때 대체 텍스트가 표시돼요
+- 검색 엔진이 이미지 내용을 이해하는 데 도움이 돼요
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="" />
+
+<!-- 수정 후 — 상품명과 이미지 설명을 넣어주세요 -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="상품 메인 이미지" />
+```
+
+별점 아이콘은 장식용이므로 빈 `alt`와 `aria-hidden`을 사용하면 돼요:
+```html
+<!-- 수정 전 -->
+<img src="/src/assets/icon/star.svg" />
+
+<!-- 수정 후 -->
+<img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+```
+
+---
+
+### 3-6. `detail-main.html`의 `id`에 공백이 들어갔어요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/product/detail/components/detail-main.html 5번째 줄 -->
+<figure id="product-gallery " class="flex flex-col ...">
+                            ^
+                      여기 공백이 있어요!
+```
+
+**왜 개선하면 좋을까?**
+
+HTML의 `id` 속성에 공백이 들어가면 `document.querySelector("#product-gallery ")`로 정확히 공백까지 넣어야 찾을 수 있어요. 나중에 JavaScript에서 이 요소를 찾으려고 `document.querySelector("#product-gallery")`를 쓰면 **null이 반환돼서 에러**가 나요.
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<figure id="product-gallery " class="flex flex-col ...">
+
+<!-- 수정 후 — 공백 제거 -->
+<figure id="product-gallery" class="flex flex-col ...">
+```
+
+---
+
+### 3-7. 회원가입 에러 아이콘이 처음부터 보여요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/signup/index.html — 아이디 입력 필드 -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idErrorIcon" />
+<img src="/src/assets/icon/check.svg" alt="아이디 통과"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idCheckIcon" />
+```
+
+**왜 개선하면 좋을까?**
+
+에러 아이콘(빨간 X)과 통과 아이콘(초록 체크)이 **페이지 로딩 직후부터 동시에 보여요!** 사용자가 아직 아무것도 입력하지 않았는데 에러 표시가 나오면 당황스러워요. 로그인 페이지에서는 `hidden` 클래스를 잘 넣어두었는데, 회원가입 페이지에서는 빠졌어요.
+
+에러 메시지(`<p>` 태그)도 같은 문제가 있어요 — 처음부터 보이고 있어요.
+
+**추천:**
+
+모든 에러/통과 아이콘과 에러 메시지에 `hidden` 클래스를 추가하세요:
+
+```html
+<!-- 수정 전 -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idErrorIcon" />
+
+<!-- 수정 후 — hidden 추가 -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 hidden"
+     id="idErrorIcon" />
+```
+
+이렇게 수정할 곳:
+- `idErrorIcon`, `idCheckIcon` (아이디)
+- `pwErrorIcon`, `pwCheckIcon` (비밀번호)
+- `pwConfirmErrorIcon`, `pwConfirmCheckIcon` (비밀번호 확인)
+- `nameErrorIcon`, `nameCheckIcon` (이름)
+- `phoneErrorIcon`, `phoneCheckIcon` (휴대폰)
+- `addressErrorIcon`, `addressCheckIcon` (주소)
+- `detailAddressErrorIcon`, `detailAddressCheckIcon` (상세주소)
+- 모든 에러 텍스트 `<p>` 태그에도 `hidden` 추가
+
+---
+
+### 3-8. 회원가입 에러 메시지가 영어로 되어 있어요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/signup/index.html -->
+<p id="pwErrorText">Password is not acceptable</p>                    <!-- 98~99번째 줄 -->
+<p id="pwConfirmErrorText">The confirmation of your password is
+    different from your original password</p>                          <!-- 142~144번째 줄 -->
+<p id="nameErrorText">Please enter your last name.</p>                 <!-- 176번째 줄 -->
+<p id="phoneErrorText">Please enter a valid phone number.</p>          <!-- 210번째 줄 -->
+```
+
+**왜 개선하면 좋을까?**
+
+나머지 UI는 모두 한국어인데, 에러 메시지만 영어예요. 한국어 사이트를 이용하는 사용자가 갑자기 영어 에러 메시지를 보면 혼란스러워요. **언어 일관성**은 사용자 경험(UX)의 기본이에요.
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<p id="pwErrorText">Password is not acceptable</p>
+<p id="pwConfirmErrorText">The confirmation of your password is different from your original password</p>
+<p id="nameErrorText">Please enter your last name.</p>
+<p id="phoneErrorText">Please enter a valid phone number.</p>
+
+<!-- 수정 후 -->
+<p id="pwErrorText">비밀번호 형식이 올바르지 않아요.</p>
+<p id="pwConfirmErrorText">비밀번호가 일치하지 않아요.</p>
+<p id="nameErrorText">이름을 입력해주세요.</p>
+<p id="phoneErrorText">올바른 휴대폰 번호를 입력해주세요.</p>
+```
+
+---
+
+### 3-9. 테마에 정의되지 않은 색상을 UI 컴포넌트에서 사용해요 (중요도: 중간)
+
+**현재 상태:**
+
+```js
+// src/components/ui/badge.js 3~4번째 줄
+const badgeClass = {
+  SALE: "bg-burnt-orange text-white",   // ← burnt-orange 정의 안 됨!
+  BEST: "bg-teal-green text-white",     // ← teal-green 정의 안 됨!
+};
+
+// src/components/ui/product-card.js 94번째 줄
+discountRateEl.className = "text-sm text-burnt-orange font-semibold";  // ← 여기도!
+```
+
+```js
+// src/components/ui/product-card.js 16번째 줄
+card.className = "... bg-gradient-to-b from-grey-96 to-grey-94";  // ← grey-94 정의 안 됨!
+```
+
+**왜 개선하면 좋을까?**
+
+`style.css`의 `@theme`에 `--color-burnt-orange`, `--color-teal-green`, `--color-grey-94`가 정의되어 있지 않아요. Tailwind는 정의되지 않은 색상 클래스를 **무시**하기 때문에, SALE 배지의 배경색이 안 나오고, 할인율 글자색도 기본색으로 보여요.
+
+**추천:**
+
+`src/styles/style.css`의 `@theme`에 빠진 색상을 추가하세요:
+
+```css
+@theme {
+  /* 기존 색상들... */
+
+  /* UI 컴포넌트에서 사용하는 색상 추가 */
+  --color-burnt-orange: #cc5500;   /* 디자인 시안에서 정확한 값을 확인하세요 */
+  --color-teal-green: #2a9d8f;     /* 디자인 시안에서 정확한 값을 확인하세요 */
+  --color-grey-94: #f0f0f0;        /* 디자인 시안에서 정확한 값을 확인하세요 */
+  --color-dark-woody: #2d1f21;     /* button.js의 hover:bg-dark-woody용 */
+}
+```
+
+---
+
+### 3-10. 로그인에서 회원가입 링크 경로가 틀려요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/login/index.html 101번째 줄 -->
+<a href="/src/pages/signup/signup.html">회원가입</a>
+```
+
+**왜 개선하면 좋을까?**
+
+회원가입 페이지 파일은 `/src/pages/signup/index.html`인데, 링크는 `/src/pages/signup/signup.html`을 가리키고 있어요. 클릭하면 **404 에러(페이지를 찾을 수 없음)**가 나요!
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<a href="/src/pages/signup/signup.html">회원가입</a>
+
+<!-- 수정 후 -->
+<a href="/src/pages/signup/">회원가입</a>
+```
+
+---
+
+### 3-11. `<body>` 스타일이 페이지마다 달라요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- index.html -->
+<body class="bg-gray-50 text-gray-900">          <!-- Tailwind 기본 색상 -->
+
+<!-- src/pages/login/index.html -->
+<body>                                            <!-- 클래스 없음 -->
+
+<!-- src/pages/signup/index.html -->
+<body class="bg-grey-99">                         <!-- 커스텀 색상 -->
+
+<!-- src/pages/product/detail/index.html -->
+<body>                                            <!-- 클래스 없음 -->
+```
+
+**왜 개선하면 좋을까?**
+
+4개의 페이지가 각각 다른 `<body>` 스타일을 가지고 있어요:
+- `index.html`: Tailwind 기본 `gray-50` (연한 회색)
+- `login`: 클래스 없음 → `@layer base`의 `spring-wood` 적용
+- `signup`: 커스텀 `grey-99` (거의 흰색)
+- `product/detail`: 클래스 없음 → `@layer base`의 `spring-wood` 적용
+
+사용자가 페이지를 이동할 때 **배경색이 갑자기 바뀌면** 어색해요. 특히 `index.html`의 `bg-gray-50`은 `@layer base`에서 설정한 `bg-spring-wood`와 **다른 색상**이에요.
+
+**추천:**
+
+`@layer base`에서 이미 body 스타일을 정의하고 있으니, 모든 페이지에서 `<body>` 클래스를 통일하세요:
+
+```html
+<!-- 모든 페이지에서 이렇게 -->
+<body>
+  <!-- @layer base의 bg-spring-wood, text-woody-brown이 자동 적용돼요 -->
+```
+
+`index.html`의 `class="bg-gray-50 text-gray-900"`을 제거하고, `signup`의 `class="bg-grey-99"`도 제거하세요.
+
+---
+
+### 3-12. 상품 상세 페이지의 `<title>`이 "Document"예요 (중요도: 낮음)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/product/detail/index.html 6번째 줄 -->
+<title>Document</title>
+```
+
+**왜 개선하면 좋을까?**
+
+브라우저 탭에 "Document"라고 표시돼요. 사용자가 탭을 여러 개 열었을 때 어떤 탭이 어떤 페이지인지 구분할 수 없어요. 검색 엔진도 `<title>` 태그를 검색 결과 제목으로 사용해요.
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<title>Document</title>
+
+<!-- 수정 후 -->
+<title>상품 상세 | L'OcciShop</title>
+```
+
+---
+
+### 3-13. 회원가입 "주소" 필드에 `required`가 붙어 있어요 (중요도: 낮음)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/signup/index.html 214~224번째 줄 -->
+<label for="userAddress" class="...">주소</label>      <!-- 별표(*)가 없음 = 선택 항목 -->
+<input type="text" id="userAddress" ... required />     <!-- 그런데 required가 있어요! -->
+```
+
+"상세주소" 필드(248~253번째 줄)도 마찬가지예요.
+
+**왜 개선하면 좋을까?**
+
+라벨에 `*`(별표)가 없으므로 선택 항목으로 보이는데, `required` 속성 때문에 **필수 입력**으로 동작해요. 사용자는 "주소는 안 써도 되겠지?"라고 생각하고 제출하면 에러가 나서 혼란스러워해요.
+
+**추천:** 둘 중 하나를 선택하세요:
+
+```html
+<!-- 방법 A: 진짜 선택 항목이면 required 제거 -->
+<input type="text" id="userAddress" name="userAddress" class="..." />
+
+<!-- 방법 B: 필수 항목이면 라벨에 별표 추가 -->
+<label for="userAddress">주소*</label>
+<input type="text" id="userAddress" name="userAddress" class="..." required />
+```
+
+---
+
+### 3-14. index.js의 역할이 너무 많아요 — 응집도를 높이면 좋겠어요 (중요도: 낮음)
+
+**현재 상태:**
+
+```js
+// src/pages/product/detail/index.js — 이 하나의 파일이 하는 일:
+async function initProductPage() {
+  // 1. HTML 파일 로딩 (fetch)
+  // 2. 배지 생성 및 교체
+  // 3. 장바구니 버튼 생성 및 이벤트 바인딩
+  // 4. 상세 정보 HTML 로딩
+  // 5. 드로어 3개 생성 및 이벤트 바인딩
+}
+```
+
+**왜 개선하면 좋을까?**
+
+이 파일은 지금 5가지 일을 하고 있어요. 지금은 코드 양이 적어서 괜찮지만, 상품 데이터를 API에서 가져오고, 리뷰를 표시하고, 옵션 선택 기능을 추가하면 이 파일이 **100줄, 200줄, 300줄...** 으로 계속 커질 거예요.
+
+**응집도(Cohesion)**란 "하나의 모듈이 하나의 목적에 집중하는 정도"예요. 지금 `index.js`는 여러 목적이 섞여 있어서 응집도가 낮아요.
+
+**결합도(Coupling)**란 "모듈 사이의 의존 관계"예요. `index.js`가 badge, button, drawer, HTML 파일을 모두 직접 다루고 있어서 결합도가 높아요.
+
+**추천:** 기능별로 함수를 분리하세요 (지금 당장은 아니더라도, 코드가 커질 때):
+
+```js
+// 지금 구조 (모든 것이 한 함수에)
+async function initProductPage() {
+  // HTML 로딩 + 배지 + 버튼 + 드로어 전부 여기에...
+}
+
+// 더 좋은 구조 (역할별로 분리)
+function initBadge() { /* 배지 관련 코드만 */ }
+function initCartButton() { /* 장바구니 버튼 코드만 */ }
+function initDrawers() { /* 드로어 관련 코드만 */ }
+
+async function initProductPage() {
+  await loadHTML();     // HTML 로딩만
+  initBadge();          // 배지 초기화만
+  initCartButton();     // 장바구니만
+  initDrawers();        // 드로어만
+}
+```
+
+이렇게 하면 "장바구니 버튼에 버그가 있다" → `initCartButton()` 함수만 보면 돼요!
+
+---
+
+## 4. 파일별 요약
+
+| 파일 | 완성도 | 주요 피드백 |
+|------|--------|-------------|
+| `index.html` | 80% | 시맨틱 태그 좋음. `<body>` 클래스 통일 필요 |
+| `vite.config.js` | 50% | 빌드 경로 오류, 누락된 페이지 추가 필요 |
+| `src/styles/style.css` | 70% | `#7E717` 오류, `--color--grey-99` 중복, 빠진 색상 다수 |
+| `src/js/main.js` | 50% | CSS import만 있음 |
+| `src/pages/login/index.html` | 60% | 접근성 좋음. 반응형/버튼색/회원가입 링크 수정 필요 |
+| `src/pages/signup/index.html` | 55% | 접근성 좋음. 아이콘 hidden 누락, 영어 메시지, required 불일치 |
+| `src/pages/product/detail/index.html` | 60% | 시맨틱 좋음. title 수정 필요 |
+| `src/pages/product/detail/index.js` | 75% | 컴포넌트 활용 좋음. 함수 분리하면 더 좋아요 |
+| `detail-main.html` | 70% | 시맨틱 좋음. alt 속성, id 공백 수정 필요 |
+| `detail-info.html` | 65% | 큰따옴표 중복 오류 수정 필요 |
+| `src/components/ui/badge.js` | 80% | 구조 좋음. 미정의 색상 추가 필요 |
+| `src/components/ui/button.js` | 90% | variant/size 패턴 훌륭! |
+| `src/components/ui/drawer.js` | 90% | 애니메이션 처리 세련됨! |
+| `src/components/ui/product-card.js` | 75% | 구조 좋음. 미정의 색상 추가 필요 |
+| `src/components/ui/tag.js` | 90% | 깔끔한 구조! |
+| `.gitignore` | 40% | package.json 제외 문제 심각 |
+
+---
+
+## 5. 다음 단계 제안
+
+1. **`.gitignore`에서 `package-lock.json` 줄 삭제** — 프로젝트 협업의 기반! (1분)
+2. **`vite.config.js` 빌드 경로 수정** — 배포가 안 되는 치명적 문제 (3분)
+3. **`detail-info.html` 큰따옴표 중복 수정** — 단순 오타 (1분)
+4. **로그인 버튼 `bg--woody-brown` → `bg-woody-brown` 수정** — 단순 오타 (1분)
+5. **`style.css`에 빠진 색상 변수 추가** — UI 컴포넌트가 제대로 표시되려면 필수 (5분)
+6. **이전 리뷰 미해결 항목 정리** — `#7E717`, `--color--grey-99`, 중복 변수 (5분)
+7. **회원가입 아이콘/메시지에 `hidden` 추가** — 사용자 경험 개선 (10분)
+8. **회원가입 에러 메시지 한국어로 통일** — 언어 일관성 (5분)
+9. **이미지 `alt` 속성 채우기** — 접근성 개선 (5분)
+10. **로그인/회원가입 JS 기능 구현** — 폼 유효성 검사 및 API 연동 (30분+)
+
+---
+
+## 6. 마무리
+
+이전 리뷰 때와 비교하면 프로젝트가 **눈에 띄게 성장**했어요!
+
+특히 인상적인 점:
+- **UI 컴포넌트 시스템을 직접 만든 것!** — badge, button, drawer, tag, product-card. 실무에서 디자인 시스템을 만드는 과정과 비슷해요. 각 컴포넌트가 하나의 역할에 집중하고(높은 응집도), 독립적으로 사용할 수 있게(낮은 결합도) 설계한 것이 훌륭해요.
+- **시맨틱 HTML을 잘 활용한 것!** — `<article>`, `<figure>`, `<section>`, `<header>`, `<label for="...">` 등이 적절하게 사용되고 있어요.
+- **프로젝트 구조가 체계적인 것!** — `pages/`, `components/ui/`, `assets/` 로 역할별로 잘 나눠져 있어요.
+
+대부분의 개선 항목은 오타나 누락으로 인한 것이고, **설계 방향 자체는 아주 좋아요!** 클래스명의 하이픈 실수, 색상 변수 누락 같은 것은 누구나 할 수 있는 실수에요. 중요한 것은 이런 실수를 찾고 고쳐나가는 과정이고, 여러분은 그것을 잘 해내고 있어요.
+
+다음 리뷰 때 로그인/회원가입의 JavaScript 기능(폼 검증, API 연동)이 완성된 모습을 보고 싶어요. 지금 속도라면 분명 잘 해낼 거예요. 파이팅!

--- a/docs/2026040614_리뷰_해결.md
+++ b/docs/2026040614_리뷰_해결.md
@@ -1,0 +1,668 @@
+# 리뷰 해결 가이드
+
+> 리뷰 날짜: 2026-04-06
+> 대상: L'OcciShop 클론 프로젝트 (록시땅 쇼핑몰 클론)
+> 원본 리뷰: [2026040614_리뷰.md](./2026040614_리뷰.md)
+> 이전 해결 가이드: [2026040314_리뷰_해결.md](./2026040314_리뷰_해결.md)
+
+---
+
+## 3-1. `.gitignore`에서 `package.json`과 `package-lock.json` 제외 문제 (중요도: 높음)
+
+### 문제
+
+`.gitignore` 27~28번째 줄에서 `packge.json`(오타)과 `package-lock.json`이 Git 추적에서 제외되고 있어요.
+
+### 해결 방법
+
+**Step 1.** `.gitignore` 파일을 열고 27~28번째 줄을 삭제하세요.
+
+```gitignore
+# 수정 전 (.gitignore 27~28번째 줄)
+packge.json
+package-lock.json
+
+# 수정 후 — 위 두 줄을 완전히 삭제하세요!
+```
+
+**Step 2.** `package-lock.json`이 이미 `.gitignore`에 의해 무시되고 있으므로, 다시 추적하도록 해주세요.
+
+```bash
+# 터미널에서 실행
+git add --force package-lock.json
+git commit -m "fix: package-lock.json을 Git 추적에 다시 포함"
+```
+
+> **쉽게 말하면:** `package.json`은 레시피(어떤 재료가 필요한지), `package-lock.json`은 정확한 재료 목록(어떤 브랜드의 몇 g인지)이에요. 이 두 파일이 없으면 다른 사람이 같은 요리를 만들 수 없어요!
+
+---
+
+## 3-2. `vite.config.js` 빌드 경로 수정 (중요도: 높음)
+
+### 문제
+
+`vite.config.js` 15번째 줄에서 `src/pages/product-detail.html`을 참조하지만, 실제 파일은 `src/pages/product/detail/index.html`에 있어요. 로그인과 회원가입 페이지도 빌드 설정에 빠져 있어요.
+
+### 해결 방법
+
+**Step 1.** `vite.config.js`를 열고 `build.rollupOptions.input`을 수정하세요.
+
+```js
+// 수정 전 (vite.config.js 13~18번째 줄)
+build: {
+  rollupOptions: {
+    input: {
+      main: resolve(__dirname, "index.html"),
+      productDetail: resolve(__dirname, "src/pages/product-detail.html"),
+    },
+  },
+},
+
+// 수정 후
+build: {
+  rollupOptions: {
+    input: {
+      main: resolve(__dirname, "index.html"),
+      login: resolve(__dirname, "src/pages/login/index.html"),
+      signup: resolve(__dirname, "src/pages/signup/index.html"),
+      productDetail: resolve(__dirname, "src/pages/product/detail/index.html"),
+    },
+  },
+},
+```
+
+**Step 2.** 수정 후 빌드가 되는지 확인하세요.
+
+```bash
+npm run build
+```
+
+에러 없이 `dist/` 폴더가 생기면 성공이에요!
+
+> **쉽게 말하면:** 택배 보낼 때 주소가 틀리면 배달이 안 되잖아요. 파일 경로도 정확해야 빌드(배달)가 돼요!
+
+---
+
+## 3-3. `detail-info.html` 큰따옴표 중복 수정 (중요도: 높음)
+
+### 문제
+
+`src/pages/product/detail/components/detail-info.html`의 16번째 줄과 23번째 줄에서 `class` 속성 끝에 큰따옴표가 두 개(`""`) 있어요.
+
+### 해결 방법
+
+**Step 1.** `detail-info.html`을 열고 16번째 줄을 수정하세요.
+
+```html
+<!-- 수정 전 (16번째 줄) -->
+<button
+  id="ingredients"
+  class="flex justify-between items-center w-full px-3 py-2.5 rounded-sm leading-5 text-sm bg-merino hover:bg-cararra""
+>
+
+<!-- 수정 후 — 맨 끝 큰따옴표 하나 제거 -->
+<button
+  id="ingredients"
+  class="flex justify-between items-center w-full px-3 py-2.5 rounded-sm leading-5 text-sm bg-merino hover:bg-cararra"
+>
+```
+
+**Step 2.** 23번째 줄도 같은 방식으로 수정하세요.
+
+```html
+<!-- 수정 전 (23번째 줄) -->
+<button
+  id="productDisclosure"
+  class="flex justify-between items-center w-full px-3 py-2.5 rounded-sm leading-5 text-sm bg-merino hover:bg-cararra""
+>
+
+<!-- 수정 후 -->
+<button
+  id="productDisclosure"
+  class="flex justify-between items-center w-full px-3 py-2.5 rounded-sm leading-5 text-sm bg-merino hover:bg-cararra"
+>
+```
+
+VS Code에서 찾기(`Ctrl+H` / `Cmd+H`):
+- 찾기: `cararra""`
+- 바꾸기: `cararra"`
+
+> **쉽게 말하면:** 문장 끝에 마침표를 두 개 찍으면 어색하잖아요.. (이것처럼요!) 따옴표도 하나만 있어야 해요.
+
+---
+
+## 3-4. 로그인 버튼 `bg--woody-brown` 수정 (중요도: 높음)
+
+### 문제
+
+`src/pages/login/index.html` 97번째 줄의 로그인 버튼에서 `bg--woody-brown`(하이픈 두 개)으로 되어 있어서 배경색이 적용되지 않아요.
+
+### 해결 방법
+
+**Step 1.** `src/pages/login/index.html`을 열고 97번째 줄을 수정하세요.
+
+```html
+<!-- 수정 전 (97번째 줄) -->
+<button
+  type="submit"
+  class="w-60 h-10 bg--woody-brown text-white-solid text-[14px] font-medium leading-6 mt-4"
+>
+
+<!-- 수정 후 — bg- 뒤의 하이픈 하나 제거 -->
+<button
+  type="submit"
+  class="w-60 h-10 bg-woody-brown text-white-solid text-[14px] font-medium leading-6 mt-4"
+>
+```
+
+> **쉽게 말하면:** 전화번호에 `-`를 하나 더 넣으면 전화가 안 걸리는 것처럼, CSS 클래스 이름도 정확해야 스타일이 적용돼요!
+
+---
+
+## 3-5. 상품 이미지 `alt` 속성 보강 (중요도: 중간)
+
+### 문제
+
+`src/pages/product/detail/components/detail-main.html`의 상품 이미지 8개 모두 `alt=""`이고, 별점 아이콘 5개는 `alt` 속성 자체가 없어요.
+
+### 해결 방법
+
+**Step 1.** 메인 이미지와 서브 이미지에 설명을 넣으세요.
+
+```html
+<!-- 수정 전 (7번째 줄) -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="" />
+
+<!-- 수정 후 -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="상품 메인 이미지" />
+```
+
+서브 이미지들도:
+```html
+<!-- 수정 전 -->
+<li><img class="bg-merino" src="/src/assets/images/product1_1.webp" alt="" /></li>
+
+<!-- 수정 후 -->
+<li><img class="bg-merino" src="/src/assets/images/product1_1.webp" alt="상품 상세 이미지 1" /></li>
+<li><img class="bg-merino" src="/src/assets/images/product1_2.webp" alt="상품 상세 이미지 2" /></li>
+<!-- ... 나머지도 번호를 매겨주세요 -->
+```
+
+**Step 2.** 별점 아이콘은 장식용이므로 빈 `alt`를 넣고 스크린리더에서 숨겨주세요.
+
+```html
+<!-- 수정 전 (73~77번째 줄) -->
+<div id="rating-stars" class="flex">
+  <img src="/src/assets/icon/star.svg" />
+  <img src="/src/assets/icon/star.svg" />
+  <img src="/src/assets/icon/star.svg" />
+  <img src="/src/assets/icon/star.svg" />
+  <img src="/src/assets/icon/star.svg" />
+</div>
+
+<!-- 수정 후 — role과 aria-label로 별점 정보를 한 번에 전달 -->
+<div id="rating-stars" class="flex" role="img" aria-label="별점 5점 만점에 5점">
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+</div>
+```
+
+> **쉽게 말하면:** 눈을 감고 쇼핑한다고 상상해보세요. "이미지"라고만 들리면 뭔지 모르잖아요. "상품 메인 이미지"라고 알려줘야 해요!
+
+---
+
+## 3-6. `detail-main.html` id 공백 제거 (중요도: 중간)
+
+### 문제
+
+`src/pages/product/detail/components/detail-main.html` 5번째 줄에서 `id="product-gallery "` 끝에 공백이 있어요.
+
+### 해결 방법
+
+**Step 1.** 5번째 줄에서 공백을 제거하세요.
+
+```html
+<!-- 수정 전 (5번째 줄) -->
+<figure id="product-gallery " class="flex flex-col gap-2 w-[60%] max-w-182">
+
+<!-- 수정 후 — "product-gallery" 뒤의 공백 제거 -->
+<figure id="product-gallery" class="flex flex-col gap-2 w-[60%] max-w-182">
+```
+
+> **쉽게 말하면:** 택배 송장에 이름 뒤에 빈칸이 들어가면 배송 조회가 안 될 수 있는 것처럼, id에 공백이 있으면 JavaScript에서 찾을 때 문제가 생겨요!
+
+---
+
+## 3-7. 회원가입 아이콘/메시지에 `hidden` 추가 (중요도: 중간)
+
+### 문제
+
+`src/pages/signup/index.html`에서 에러 아이콘, 통과 아이콘, 에러 메시지가 페이지 로딩 시부터 모두 보여요.
+
+### 해결 방법
+
+모든 에러/통과 아이콘과 에러 메시지에 `hidden` 클래스를 추가해야 해요. 파일에서 수정할 곳이 많으니 **VS Code 찾기/바꾸기**를 활용하세요.
+
+**Step 1.** 아이디 필드의 아이콘과 메시지 (32~51번째 줄)
+
+```html
+<!-- 수정 전 (36번째 줄) -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idErrorIcon" />
+
+<!-- 수정 후 — hidden 추가 -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 hidden"
+     id="idErrorIcon" />
+```
+
+```html
+<!-- 수정 전 (40번째 줄) -->
+<img src="/src/assets/icon/check.svg" alt="아이디 통과"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idCheckIcon" />
+
+<!-- 수정 후 -->
+<img src="/src/assets/icon/check.svg" alt="아이디 통과"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 hidden"
+     id="idCheckIcon" />
+```
+
+```html
+<!-- 수정 전 (46~51번째 줄) -->
+<p class="text-error-red text-[12px] font-medium leading-4 mb-4"
+   id="idErrorText">
+  잘못된 형식입니다.
+</p>
+
+<!-- 수정 후 — hidden 추가 -->
+<p class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden"
+   id="idErrorText">
+  잘못된 형식입니다.
+</p>
+```
+
+**Step 2.** 나머지 필드도 같은 방식으로 수정하세요.
+
+수정할 요소 목록 (모두 `hidden` 추가):
+
+| 요소 ID | 줄 번호 (대략) | 유형 |
+|---------|---------------|------|
+| `idErrorIcon` | 36 | 에러 아이콘 |
+| `idCheckIcon` | 40 | 통과 아이콘 |
+| `idErrorText` | 46 | 에러 메시지 |
+| `pwErrorIcon` | 70 | 에러 아이콘 |
+| `pwCheckIcon` | 75 | 통과 아이콘 |
+| `pwGuideText` | 90 | - (이건 가이드니까 보여도 돼요!) |
+| `pwErrorText` | 96 | 에러 메시지 |
+| `pwConfirmErrorIcon` | 120 | 에러 아이콘 |
+| `pwConfirmCheckIcon` | 125 | 통과 아이콘 |
+| `pwConfirmErrorText` | 139 | 에러 메시지 |
+| `nameErrorIcon` | 160 | 에러 아이콘 |
+| `nameCheckIcon` | 165 | 통과 아이콘 |
+| `nameErrorText` | 173 | 에러 메시지 |
+| `phoneErrorIcon` | 196 | 에러 아이콘 |
+| `phoneCheckIcon` | 201 | 통과 아이콘 |
+| `phoneErrorText` | 208 | 에러 메시지 |
+| `addressErrorIcon` | 229 | 에러 아이콘 |
+| `addressCheckIcon` | 234 | 통과 아이콘 |
+| `detailAddressErrorIcon` | 256 | 에러 아이콘 |
+| `detailAddressCheckIcon` | 261 | 통과 아이콘 |
+
+**팁:** JavaScript에서 유효성 검사 후 아이콘을 보여줄 때는 이렇게 하면 돼요:
+
+```js
+// 에러 표시
+document.getElementById("idErrorIcon").classList.remove("hidden");
+document.getElementById("idErrorText").classList.remove("hidden");
+
+// 통과 표시
+document.getElementById("idCheckIcon").classList.remove("hidden");
+document.getElementById("idErrorIcon").classList.add("hidden");
+```
+
+> **쉽게 말하면:** 시험지를 나눠주면서 동시에 "오답!" 도장을 찍어놓으면 안 되잖아요. 학생이 답을 쓴 다음에 채점해야 해요!
+
+---
+
+## 3-8. 회원가입 에러 메시지 한국어로 통일 (중요도: 중간)
+
+### 문제
+
+`src/pages/signup/index.html`에서 일부 에러 메시지가 영어로 되어 있어요.
+
+### 해결 방법
+
+**Step 1.** 아래 4군데를 한국어로 변경하세요.
+
+```html
+<!-- 수정 전 (98~99번째 줄) -->
+<p id="pwErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4">
+  Password is not acceptable
+</p>
+
+<!-- 수정 후 -->
+<p id="pwErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden">
+  비밀번호 형식이 올바르지 않아요.
+</p>
+```
+
+```html
+<!-- 수정 전 (142~144번째 줄) -->
+<p id="pwConfirmErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4">
+  The confirmation of your password is different from your original password
+</p>
+
+<!-- 수정 후 -->
+<p id="pwConfirmErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden">
+  비밀번호가 일치하지 않아요.
+</p>
+```
+
+```html
+<!-- 수정 전 (176번째 줄) -->
+<p id="nameErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4">
+  Please enter your last name.
+</p>
+
+<!-- 수정 후 -->
+<p id="nameErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden">
+  이름을 입력해주세요.
+</p>
+```
+
+```html
+<!-- 수정 전 (210번째 줄) -->
+<p id="phoneErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4">
+  Please enter a valid phone number.
+</p>
+
+<!-- 수정 후 -->
+<p id="phoneErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden">
+  올바른 휴대폰 번호를 입력해주세요.
+</p>
+```
+
+> **쉽게 말하면:** 한국어 안내서 중간에 갑자기 영어가 나오면 "잉?" 하잖아요. 사용자 입장에서 모든 안내가 같은 언어로 나와야 자연스러워요!
+
+---
+
+## 3-9. 테마에 빠진 색상 변수 추가 (중요도: 중간)
+
+### 문제
+
+`badge.js`, `button.js`, `product-card.js`에서 사용하는 색상이 `style.css`의 `@theme`에 정의되어 있지 않아서 해당 색상이 적용되지 않아요.
+
+### 해결 방법
+
+**Step 1.** `src/styles/style.css`의 `@theme` 블록에 아래 색상을 추가하세요.
+
+```css
+/* 수정 전 (src/styles/style.css) */
+@theme {
+  /* 기존 색상들... */
+  --color-orange-90: #e8e4e2;
+}
+
+/* 수정 후 — 아래 색상들을 @theme 블록 안에 추가 */
+@theme {
+  /* 기존 색상들... */
+  --color-orange-90: #e8e4e2;
+
+  /* UI 컴포넌트용 색상 (디자인 시안에서 정확한 값을 확인해주세요!) */
+  --color-burnt-orange: #cc5500;    /* badge.js SALE, product-card.js 할인율 */
+  --color-teal-green: #2a9d8f;     /* badge.js BEST */
+  --color-grey-94: #f0f0f0;        /* product-card.js 카드 그라데이션 */
+  --color-dark-woody: #2d1f21;     /* button.js hover 색상 */
+}
+```
+
+**Step 2.** 디자인 시안(Figma 등)에서 정확한 색상값을 확인하세요. 위의 값은 임시값이에요!
+
+> **쉽게 말하면:** 레고를 조립하는데 설명서에 "빨간 블록을 끼우세요"라고 하는데 상자에 빨간 블록이 없으면 완성할 수 없잖아요. CSS 변수가 그 블록이에요!
+
+---
+
+## 3-10. 로그인 → 회원가입 링크 경로 수정 (중요도: 중간)
+
+### 문제
+
+`src/pages/login/index.html` 101번째 줄에서 회원가입 링크가 존재하지 않는 파일을 가리키고 있어요.
+
+### 해결 방법
+
+**Step 1.** 링크 경로를 수정하세요.
+
+```html
+<!-- 수정 전 (101번째 줄) -->
+<a href="/src/pages/signup/signup.html">회원가입</a>
+
+<!-- 수정 후 -->
+<a href="/src/pages/signup/">회원가입</a>
+```
+
+> **쉽게 말하면:** 내비게이션에 잘못된 주소를 넣으면 목적지에 도착할 수 없잖아요!
+
+---
+
+## 3-11. `<body>` 스타일 통일 (중요도: 중간)
+
+### 문제
+
+4개 페이지의 `<body>` 스타일이 각각 달라서, 페이지 이동 시 배경색이 바뀌어요.
+
+### 해결 방법
+
+**Step 1.** `index.html`의 `<body>` 클래스를 제거하세요.
+
+```html
+<!-- 수정 전 (index.html 9번째 줄) -->
+<body class="bg-gray-50 text-gray-900">
+
+<!-- 수정 후 -->
+<body>
+```
+
+**Step 2.** `signup/index.html`의 `<body>` 클래스도 제거하세요.
+
+```html
+<!-- 수정 전 (signup/index.html 9번째 줄) -->
+<body class="bg-grey-99">
+
+<!-- 수정 후 -->
+<body>
+```
+
+이렇게 하면 모든 페이지에서 `@layer base`의 기본 스타일(`bg-spring-wood text-woody-brown`)이 적용돼요.
+
+**Step 3.** 만약 회원가입 페이지만 배경색이 달라야 한다면, `<body>` 대신 `<main>` 태그에 배경색을 넣으세요.
+
+```html
+<body>
+  <main class="bg-grey-99 flex justify-center items-center">
+```
+
+> **쉽게 말하면:** 방마다 벽지가 제각각이면 집이 어수선해 보여요. 기본 벽지를 통일하고, 특별한 방만 따로 꾸미세요!
+
+---
+
+## 3-12. 상품 상세 `<title>` 수정 (중요도: 낮음)
+
+### 문제
+
+`src/pages/product/detail/index.html` 6번째 줄의 `<title>`이 기본값 "Document"예요.
+
+### 해결 방법
+
+```html
+<!-- 수정 전 (6번째 줄) -->
+<title>Document</title>
+
+<!-- 수정 후 -->
+<title>상품 상세 | L'OcciShop</title>
+```
+
+> **쉽게 말하면:** 브라우저 탭에 "Document"라고 표시되면 "이게 뭐지?" 하잖아요. 페이지 이름표를 달아주세요!
+
+---
+
+## 3-13. 회원가입 "주소" 필드 `required` 수정 (중요도: 낮음)
+
+### 문제
+
+`src/pages/signup/index.html` 224번째 줄과 253번째 줄의 "주소"와 "상세주소" 입력란에 `required`가 있는데, 라벨에는 `*`(필수 표시)가 없어요.
+
+### 해결 방법
+
+**방법 A: 선택 항목으로 처리** (추천)
+
+```html
+<!-- 수정 전 (224번째 줄) -->
+<input type="text" id="userAddress" name="userAddress"
+       class="bg-grey-96 border border-grey-45 ..."
+       required />
+
+<!-- 수정 후 — required 제거 -->
+<input type="text" id="userAddress" name="userAddress"
+       class="bg-grey-96 border border-grey-45 ..." />
+```
+
+상세주소(253번째 줄)도 같은 방식으로 `required`를 제거하세요.
+
+**방법 B: 필수 항목으로 처리**
+
+```html
+<!-- 수정 전 (214번째 줄) -->
+<label for="userAddress" class="...">주소</label>
+
+<!-- 수정 후 — 별표 추가 -->
+<label for="userAddress" class="...">주소*</label>
+```
+
+> **쉽게 말하면:** 시험지에 "선택 문제"라고 써놓고 안 풀면 감점하면 학생이 억울하잖아요. 필수면 필수라고, 선택이면 선택이라고 정확히 알려줘야 해요!
+
+---
+
+## 3-14. `index.js` 함수 분리로 응집도 높이기 (중요도: 낮음)
+
+### 문제
+
+`src/pages/product/detail/index.js`의 `initProductPage()` 함수가 HTML 로딩, 배지 생성, 버튼 생성, 드로어 생성 등 5가지 역할을 동시에 해요.
+
+### 해결 방법
+
+지금 당장 수정하지 않아도 되지만, 코드가 더 커질 때 이렇게 분리하면 좋아요.
+
+**Step 1.** 기능별로 함수를 분리하세요.
+
+```js
+// 수정 전 (현재 index.js)
+async function initProductPage() {
+  const container = document.querySelector("#detail-main");
+  if (!container) return;
+
+  // 60줄이 넘는 코드가 한 함수에...
+  const res = await fetch("...");
+  container.innerHTML = await res.text();
+  const badge = createBadge({ type: "NEW" });
+  // ...장바구니 버튼...
+  // ...드로어 3개...
+}
+
+// 수정 후 — 역할별로 분리
+import { createButton } from "/src/components/ui/button.js";
+import { createBadge } from "/src/components/ui/badge.js";
+import { createDrawer } from "/src/components/ui/drawer.js";
+
+/** HTML 파일을 로드해서 컨테이너에 삽입 */
+async function loadHTML(selector, url) {
+  const container = document.querySelector(selector);
+  if (!container) return;
+  const res = await fetch(url);
+  container.innerHTML = await res.text();
+}
+
+/** 배지 초기화 */
+function initBadge() {
+  const badge = createBadge({ type: "NEW" });
+  document.querySelector("#badge").replaceWith(badge);
+}
+
+/** 장바구니 버튼 초기화 */
+function initCartButton() {
+  const cartBtn = createButton({
+    text: "장바구니에 추가",
+    variant: "primary",
+    size: "md",
+    fullWidth: true,
+  });
+  cartBtn.addEventListener("click", () => {
+    console.log("장바구니 추가!");
+  });
+  document.querySelector("#cart-button").append(cartBtn);
+}
+
+/** 드로어 초기화 */
+function initDrawers() {
+  const drawers = [
+    { title: "사용 방법", btnId: "#howToUse", content: "<p>사용 방법 내용</p>" },
+    { title: "원료", btnId: "#ingredients", content: "<p>원료 내용</p>" },
+    { title: "상품정보 제공고시", btnId: "#productDisclosure", content: "<p>상품정보 내용</p>" },
+  ];
+
+  drawers.forEach(({ title, btnId, content }) => {
+    const drawer = createDrawer({ title, position: "right" });
+    drawer.content.innerHTML = content;
+    document.querySelector(btnId).addEventListener("click", () => {
+      drawer.open();
+    });
+  });
+}
+
+/** 메인 초기화 함수 — 각 역할을 호출만 해요 */
+async function initProductPage() {
+  await loadHTML("#detail-main", "/src/pages/product/detail/components/detail-main.html");
+  initBadge();
+  initCartButton();
+
+  await loadHTML("#product-info", "/src/pages/product/detail/components/detail-info.html");
+  initDrawers();
+}
+
+document.addEventListener("DOMContentLoaded", initProductPage);
+```
+
+이렇게 분리하면:
+- **응집도 UP**: 각 함수가 하나의 역할만 해요
+- **결합도 DOWN**: 드로어를 수정할 때 `initDrawers()`만 보면 돼요
+- **가독성 UP**: `initProductPage()`를 읽으면 전체 흐름이 한눈에 보여요
+- **테스트 쉬움**: 각 함수를 독립적으로 테스트할 수 있어요
+
+> **쉽게 말하면:** 요리할 때 "재료 손질", "볶기", "소스 만들기", "플레이팅"을 한 사람이 해도 되지만, 각 단계를 명확히 나누면 어디서 실수했는지 찾기 쉽고, 다른 요리에도 같은 소스를 쓸 수 있어요!
+
+---
+
+## 수정 우선순위 체크리스트
+
+| 순서 | 항목 | 난이도 | 예상 시간 |
+|------|------|--------|-----------|
+| 1 | 3-4. 로그인 버튼 `bg--woody-brown` 수정 | 쉬움 | 1분 |
+| 2 | 3-3. detail-info.html 큰따옴표 중복 | 쉬움 | 1분 |
+| 3 | 3-6. detail-main.html id 공백 제거 | 쉬움 | 1분 |
+| 4 | 3-12. 상품 상세 `<title>` 수정 | 쉬움 | 1분 |
+| 5 | 3-10. 회원가입 링크 경로 수정 | 쉬움 | 1분 |
+| 6 | 3-1. `.gitignore` 수정 | 쉬움 | 2분 |
+| 7 | 3-2. `vite.config.js` 빌드 경로 수정 | 쉬움 | 3분 |
+| 8 | 3-8. 에러 메시지 한국어 통일 | 쉬움 | 3분 |
+| 9 | 3-11. `<body>` 스타일 통일 | 쉬움 | 3분 |
+| 10 | 3-9. 테마 색상 변수 추가 | 보통 | 5분 |
+| 11 | 3-5. 상품 이미지 alt 속성 | 보통 | 5분 |
+| 12 | 3-13. 주소 필드 required 수정 | 쉬움 | 2분 |
+| 13 | 3-7. 회원가입 아이콘 hidden 추가 | 보통 | 10분 |
+| 14 | 3-14. index.js 함수 분리 | 도전 | 20분 |
+
+> 1~9번은 모두 합쳐도 15분이면 끝나는 간단한 수정이에요! 오늘 쉬운 것부터 하나씩 체크해나가면 프로젝트가 눈에 띄게 깔끔해질 거예요. UI 컴포넌트 시스템을 직접 만든 여러분의 실력이라면 충분히 해낼 수 있어요. 파이팅!

--- a/reviews/2026040614_리뷰.md
+++ b/reviews/2026040614_리뷰.md
@@ -1,0 +1,765 @@
+# 프로젝트 코드 리뷰
+
+> 리뷰 날짜: 2026-04-06
+> 대상: L'OcciShop 클론 프로젝트 (록시땅 쇼핑몰 클론)
+> 이전 리뷰: [2026040314_리뷰.md](./2026040314_리뷰.md)
+
+---
+
+## 0. 이번 리뷰 범위
+
+이번 리뷰는 이전 리뷰(2026040314) 이후 **develop 브랜치에 머지된 변경 파일**을 대상으로 합니다. 32개 커밋이 머지되어 프로젝트가 크게 성장했어요!
+
+**변경/추가된 파일:**
+- `index.html` — 시맨틱 태그 적용, `<body>` 클래스 유지
+- `vite.config.js` — 멀티 페이지 빌드 설정 추가 (경로 오류 있음)
+- `src/styles/style.css` — `src/css/style.css`에서 이동, 테마 변수 추가
+- `src/js/main.js` — CSS import 경로 변경
+- `src/pages/login/index.html` — 로그인 페이지 (feature 브랜치에서 머지)
+- `src/pages/signup/index.html` — 회원가입 페이지 (신규)
+- `src/pages/product/detail/index.html` — 상품 상세 페이지 (신규)
+- `src/pages/product/detail/index.js` — 상품 상세 JS (신규)
+- `src/pages/product/detail/components/detail-main.html` — 상품 메인 영역 (신규)
+- `src/pages/product/detail/components/detail-info.html` — 상품 정보 영역 (신규)
+- `src/components/ui/badge.js` — 배지 UI 컴포넌트 (신규)
+- `src/components/ui/button.js` — 버튼 UI 컴포넌트 (신규)
+- `src/components/ui/drawer.js` — 드로어 UI 컴포넌트 (신규)
+- `src/components/ui/product-card.js` — 상품 카드 UI 컴포넌트 (신규)
+- `src/components/ui/tag.js` — 태그 UI 컴포넌트 (신규)
+- `src/assets/icon/*.svg` — 아이콘 9개 추가
+- `.gitignore` — 변경됨
+
+**이전 리뷰 해결된 항목:**
+잘했어요! 아래 항목들은 이전 리뷰 이후 잘 수정되었어요.
+- ~~3-8. 빈 컴포넌트 파일 (header.js, footer.js)~~ — `.gitkeep` 파일이 제거되고 실제 UI 컴포넌트(badge, button, drawer, tag, product-card)가 구현되었어요! 해결 완료!
+- ~~3-9. 아포스트로피 오타~~ — `<title>` 태그에서 `L'OcciShop`으로 올바르게 수정되었어요! 해결 완료!
+
+**이전 리뷰 미해결 항목:**
+아래 항목들은 이전 리뷰에서 지적되었지만 아직 수정되지 않았어요.
+- 3-1. `--color-empress: #7E717` 색상 코드 오류 → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-1-stylecss--잘못된-색상-코드가-있어요-중요도-높음)
+- 3-2. `--color--grey-99` 하이픈 두 개 → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-2-stylecss--css-변수-이름에-하이픈이-두-개예요-중요도-높음)
+- 3-3. 중복 색상 변수 (`woody-brown` = `brand-woody`) → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-3-stylecss--같은-색상값이-다른-이름으로-중복돼요-중요도-중간)
+- 3-4. 로그인 모달 모바일 반응형 (`w-200` 고정) → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-4-로그인-페이지--모바일에서-화면이-깨질-수-있어요-중요도-중간)
+- 3-5. 로그인 폼 `<form action="">` → [이전 리뷰에서 확인하기](./2026040314_리뷰.md#3-5-로그인-페이지--form-action이-비어-있어요-중요도-중간)
+
+---
+
+## 1. 프로젝트 구조 살펴보기
+
+```
+loccishop/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug_report.md
+│   │   └── feature_request.md
+│   └── PULL_REQUEST_TEMPLATE.md
+├── .gitignore                          ← 변경됨 (문제 있음!)
+├── docs/
+│   └── api/                            ← API 문서 11개
+├── eslint.config.js
+├── index.html                          ← 시맨틱 태그 적용됨
+├── package.json
+├── README.md
+├── reviews/
+├── src/
+│   ├── assets/
+│   │   ├── icon/
+│   │   │   ├── cart.svg               ← NEW
+│   │   │   ├── check.svg              ← NEW
+│   │   │   ├── error.svg              ← NEW
+│   │   │   ├── heart.svg              ← NEW
+│   │   │   ├── heart-empty.svg        ← NEW
+│   │   │   ├── login_xBtn.svg         ← NEW
+│   │   │   ├── logo.svg
+│   │   │   ├── passwordEye.svg        ← NEW
+│   │   │   ├── star.svg               ← NEW
+│   │   │   └── star-empty.svg         ← NEW
+│   │   └── images/
+│   │       └── product1_0~7.webp      ← NEW (상품 이미지 8개)
+│   ├── components/
+│   │   └── ui/
+│   │       ├── badge.js               ← NEW
+│   │       ├── button.js              ← NEW
+│   │       ├── drawer.js              ← NEW
+│   │       ├── product-card.js        ← NEW
+│   │       └── tag.js                 ← NEW
+│   ├── js/
+│   │   └── main.js                    ← import 경로 변경
+│   ├── pages/
+│   │   ├── login/
+│   │   │   └── index.html             ← NEW
+│   │   ├── product/
+│   │   │   └── detail/
+│   │   │       ├── components/
+│   │   │       │   ├── detail-info.html   ← NEW
+│   │   │       │   └── detail-main.html   ← NEW
+│   │   │       ├── index.html         ← NEW
+│   │   │       └── index.js           ← NEW
+│   │   └── signup/
+│   │       └── index.html             ← NEW
+│   └── styles/
+│       └── style.css                  ← src/css/ 에서 이동
+└── vite.config.js                     ← 멀티 페이지 설정 추가
+```
+
+이전 리뷰 때와 비교하면 프로젝트 구조가 훨씬 체계적으로 발전했어요! 특히 `src/components/ui/` 디렉토리에 재사용 가능한 UI 컴포넌트들을 모아둔 것이 인상적이에요.
+
+---
+
+## 2. 잘한 점
+
+### UI 컴포넌트 설계가 훌륭해요! (응집도 높음)
+
+`src/components/ui/` 디렉토리의 컴포넌트들이 **각자 하나의 역할만** 담당하고 있어요. 이것을 **높은 응집도(High Cohesion)**라고 해요 — "한 모듈이 하나의 책임만 가진다"는 뜻이에요.
+
+```js
+// badge.js — 배지만 만들어요
+export function createBadge({ type = "NEW" } = {}) { ... }
+
+// button.js — 버튼만 만들어요
+export function createButton({ text, variant, size, fullWidth } = {}) { ... }
+
+// drawer.js — 드로어만 만들어요
+export function createDrawer({ title, position } = {}) { ... }
+```
+
+각 컴포넌트가 **props(설정값)**를 받아서 DOM 요소를 반환하는 동일한 패턴을 따르고 있어요. 이렇게 하면 다른 페이지에서도 쉽게 재사용할 수 있어요!
+
+### button.js의 variant/size 패턴이 아주 좋아요!
+
+```js
+const variantClass = {
+  primary: "min-w-16 rounded bg-woody-brown ...",
+  outline: "border border-empress rounded-sm ...",
+};
+
+const sizeClass = {
+  sm: "px-4 py-2.5 text-sm",
+  md: "py-4 text-sm",
+};
+```
+
+스타일 변형(variant)과 크기(size)를 **객체로 분리**해서 관리하는 것은 실무에서도 많이 사용하는 패턴이에요. Tailwind + JavaScript 조합의 모범 사례입니다!
+
+### drawer.js의 애니메이션 처리가 세련돼요!
+
+```js
+function open() {
+  document.body.append(overlay, drawer);
+  requestAnimationFrame(() => {
+    overlay.classList.replace("opacity-0", "opacity-100");
+    drawer.classList.replace("translate-x-full", "translate-x-0");
+  });
+  document.body.style.overflow = "hidden";
+}
+```
+
+`requestAnimationFrame`을 사용해서 애니메이션을 부드럽게 처리하고, `document.body.style.overflow = "hidden"`으로 배경 스크롤을 막는 것까지 신경 쓴 것이 좋아요!
+
+### 상품 상세 페이지의 HTML 시맨틱이 좋아요!
+
+```html
+<article class="content-wrapper ...">
+  <figure id="product-gallery">        <!-- 이미지 영역 -->
+  <section id="product-main">          <!-- 상품 정보 영역 -->
+    <header>                            <!-- 상품명, 가격 -->
+```
+
+`<article>`, `<figure>`, `<section>`, `<header>` 같은 시맨틱 태그를 적절하게 사용했어요. 검색 엔진과 스크린리더가 페이지 구조를 잘 이해할 수 있어요!
+
+### ESLint 설정이 탄탄해요!
+
+```js
+rules: {
+  eqeqeq: "error",             // === 사용 강제
+  "prefer-const": "error",     // const 강제
+  "no-var": "error",           // var 금지
+  "no-implicit-globals": "error", // 전역 변수 금지
+}
+```
+
+`===` 강제, `var` 금지, 전역 변수 금지 — 초보자가 흔히 실수하는 부분을 ESLint 규칙으로 미리 잡고 있어요. 아주 좋은 방어 장치에요!
+
+### 회원가입 폼의 접근성이 좋아요!
+
+```html
+<label for="userId" class="text-[14px] font-medium leading-5">아이디*</label>
+<input type="text" id="userId" name="userId" required />
+```
+
+모든 입력 필드에 `<label>`과 `<input>`이 `for`/`id`로 올바르게 연결되어 있어요. `required` 속성도 잘 적용했어요.
+
+### 상품 상세 페이지의 컴포넌트 분리가 좋아요!
+
+```
+src/pages/product/detail/
+├── components/
+│   ├── detail-main.html    ← 메인 영역 (이미지 + 기본 정보)
+│   └── detail-info.html    ← 상세 정보 영역 (설명 + 버튼들)
+├── index.html              ← 페이지 껍데기
+└── index.js                ← 로직 담당
+```
+
+HTML을 `components/` 폴더로 분리하고 JS에서 `fetch()`로 불러오는 구조가 깔끔해요. 화면(HTML)과 동작(JS)을 분리하려는 좋은 시도예요!
+
+---
+
+## 3. 개선하면 좋을 점
+
+### 3-1. `.gitignore`에서 `package.json`과 `package-lock.json`을 제외하고 있어요 (중요도: 높음)
+
+**현재 상태:**
+
+```gitignore
+# .gitignore 27~28번째 줄
+packge.json
+package-lock.json
+```
+
+**왜 개선하면 좋을까?**
+
+`package.json`은 프로젝트의 **설계도**예요! 어떤 라이브러리를 쓰는지, 어떤 명령어를 쓸 수 있는지 다 적혀 있어요. `package-lock.json`은 **정확한 버전 기록**이에요. 이 두 파일을 `.gitignore`에 넣으면:
+
+- 새 팀원이 `git clone`한 후 `npm install`을 실행할 수 없어요
+- 팀원마다 다른 버전의 라이브러리를 설치하게 돼요
+- 빌드가 안 되거나 에러가 나는 원인이 될 수 있어요
+
+게다가 `packge.json`은 오타예요 (`package`의 `a`가 빠졌어요). 하지만 오타 덕분에 실제로 `package.json`은 추적되고 있긴 해요. `package-lock.json`은 정확히 적혀 있어서 **진짜로 Git 추적에서 제외되고 있어요!**
+
+**추천:**
+
+```gitignore
+# 수정 전
+packge.json
+package-lock.json
+
+# 수정 후 — 이 두 줄을 삭제하세요!
+# (package.json과 package-lock.json은 반드시 Git으로 관리해야 해요)
+```
+
+---
+
+### 3-2. `vite.config.js`의 빌드 경로가 실제 파일과 달라요 (중요도: 높음)
+
+**현재 상태:**
+
+```js
+// vite.config.js 14~15번째 줄
+build: {
+  rollupOptions: {
+    input: {
+      main: resolve(__dirname, "index.html"),
+      productDetail: resolve(__dirname, "src/pages/product-detail.html"),  // ← 이 경로!
+    },
+  },
+},
+```
+
+**왜 개선하면 좋을까?**
+
+`src/pages/product-detail.html`이라는 파일은 존재하지 않아요! 실제 파일은 `src/pages/product/detail/index.html`에 있어요. 이렇게 되면 `npm run build`(배포용 빌드)를 실행할 때 **에러가 나서 배포가 안 돼요**.
+
+또한 로그인 페이지(`src/pages/login/index.html`)와 회원가입 페이지(`src/pages/signup/index.html`)도 빌드 설정에 빠져 있어요.
+
+**추천:**
+
+```js
+// 수정 전
+input: {
+  main: resolve(__dirname, "index.html"),
+  productDetail: resolve(__dirname, "src/pages/product-detail.html"),
+},
+
+// 수정 후 — 실제 파일 경로에 맞추고, 모든 페이지 추가
+input: {
+  main: resolve(__dirname, "index.html"),
+  login: resolve(__dirname, "src/pages/login/index.html"),
+  signup: resolve(__dirname, "src/pages/signup/index.html"),
+  productDetail: resolve(__dirname, "src/pages/product/detail/index.html"),
+},
+```
+
+---
+
+### 3-3. `detail-info.html`에 큰따옴표가 두 번 들어갔어요 (중요도: 높음)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/product/detail/components/detail-info.html 16~17번째 줄 -->
+<button
+  id="ingredients"
+  class="flex justify-between items-center ... bg-merino hover:bg-cararra""
+>                                                                        ^^
+                                                              여기 큰따옴표가 두 개!
+```
+
+같은 문제가 22~23번째 줄(`productDisclosure` 버튼)에도 있어요.
+
+**왜 개선하면 좋을까?**
+
+HTML에서 속성값은 `"..."`로 감싸야 하는데, `""`(큰따옴표 두 개)로 끝나면 브라우저가 혼란스러워해요. 지금은 브라우저가 알아서 처리해주지만, **HTML 유효성 검사(validation)에서 오류**로 잡히고, 나중에 예상치 못한 렌더링 문제가 생길 수 있어요.
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<button
+  id="ingredients"
+  class="flex justify-between ... bg-merino hover:bg-cararra""
+>
+
+<!-- 수정 후 — 맨 끝 큰따옴표 하나 제거 -->
+<button
+  id="ingredients"
+  class="flex justify-between ... bg-merino hover:bg-cararra"
+>
+```
+
+`productDisclosure` 버튼(22번째 줄)도 같은 방식으로 수정하세요.
+
+---
+
+### 3-4. 로그인 버튼의 클래스명 `bg--woody-brown`이 동작하지 않아요 (중요도: 높음)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/login/index.html 97번째 줄 -->
+<button
+  type="submit"
+  class="w-60 h-10 bg--woody-brown text-white-solid ..."
+>                   ^^
+          하이픈이 두 개! bg--woody-brown
+```
+
+**왜 개선하면 좋을까?**
+
+Tailwind CSS에서 `bg-woody-brown`(하이픈 1개)은 `--color-woody-brown` 색상을 배경에 적용해요. 하지만 `bg--woody-brown`(하이픈 2개)은 **존재하지 않는 클래스**여서 배경색이 안 나와요. 로그인 버튼이 **배경색 없이 하얀색**으로 보일 거예요!
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<button class="w-60 h-10 bg--woody-brown text-white-solid ...">
+
+<!-- 수정 후 — 하이픈 하나로 수정 -->
+<button class="w-60 h-10 bg-woody-brown text-white-solid ...">
+```
+
+---
+
+### 3-5. 상품 이미지에 `alt` 속성이 비어 있어요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/product/detail/components/detail-main.html -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="" />
+<!-- ... 총 8개 이미지 모두 alt="" -->
+```
+
+별점 아이콘도 마찬가지예요:
+```html
+<img src="/src/assets/icon/star.svg" />  <!-- alt 속성 자체가 없음 -->
+```
+
+**왜 개선하면 좋을까?**
+
+`alt` 속성은 **접근성(Accessibility)**의 핵심이에요:
+- 시각장애인이 스크린리더를 사용할 때 이미지 내용을 음성으로 읽어줘요
+- 이미지 로딩에 실패했을 때 대체 텍스트가 표시돼요
+- 검색 엔진이 이미지 내용을 이해하는 데 도움이 돼요
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="" />
+
+<!-- 수정 후 — 상품명과 이미지 설명을 넣어주세요 -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="상품 메인 이미지" />
+```
+
+별점 아이콘은 장식용이므로 빈 `alt`와 `aria-hidden`을 사용하면 돼요:
+```html
+<!-- 수정 전 -->
+<img src="/src/assets/icon/star.svg" />
+
+<!-- 수정 후 -->
+<img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+```
+
+---
+
+### 3-6. `detail-main.html`의 `id`에 공백이 들어갔어요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/product/detail/components/detail-main.html 5번째 줄 -->
+<figure id="product-gallery " class="flex flex-col ...">
+                            ^
+                      여기 공백이 있어요!
+```
+
+**왜 개선하면 좋을까?**
+
+HTML의 `id` 속성에 공백이 들어가면 `document.querySelector("#product-gallery ")`로 정확히 공백까지 넣어야 찾을 수 있어요. 나중에 JavaScript에서 이 요소를 찾으려고 `document.querySelector("#product-gallery")`를 쓰면 **null이 반환돼서 에러**가 나요.
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<figure id="product-gallery " class="flex flex-col ...">
+
+<!-- 수정 후 — 공백 제거 -->
+<figure id="product-gallery" class="flex flex-col ...">
+```
+
+---
+
+### 3-7. 회원가입 에러 아이콘이 처음부터 보여요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/signup/index.html — 아이디 입력 필드 -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idErrorIcon" />
+<img src="/src/assets/icon/check.svg" alt="아이디 통과"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idCheckIcon" />
+```
+
+**왜 개선하면 좋을까?**
+
+에러 아이콘(빨간 X)과 통과 아이콘(초록 체크)이 **페이지 로딩 직후부터 동시에 보여요!** 사용자가 아직 아무것도 입력하지 않았는데 에러 표시가 나오면 당황스러워요. 로그인 페이지에서는 `hidden` 클래스를 잘 넣어두었는데, 회원가입 페이지에서는 빠졌어요.
+
+에러 메시지(`<p>` 태그)도 같은 문제가 있어요 — 처음부터 보이고 있어요.
+
+**추천:**
+
+모든 에러/통과 아이콘과 에러 메시지에 `hidden` 클래스를 추가하세요:
+
+```html
+<!-- 수정 전 -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idErrorIcon" />
+
+<!-- 수정 후 — hidden 추가 -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 hidden"
+     id="idErrorIcon" />
+```
+
+이렇게 수정할 곳:
+- `idErrorIcon`, `idCheckIcon` (아이디)
+- `pwErrorIcon`, `pwCheckIcon` (비밀번호)
+- `pwConfirmErrorIcon`, `pwConfirmCheckIcon` (비밀번호 확인)
+- `nameErrorIcon`, `nameCheckIcon` (이름)
+- `phoneErrorIcon`, `phoneCheckIcon` (휴대폰)
+- `addressErrorIcon`, `addressCheckIcon` (주소)
+- `detailAddressErrorIcon`, `detailAddressCheckIcon` (상세주소)
+- 모든 에러 텍스트 `<p>` 태그에도 `hidden` 추가
+
+---
+
+### 3-8. 회원가입 에러 메시지가 영어로 되어 있어요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/signup/index.html -->
+<p id="pwErrorText">Password is not acceptable</p>                    <!-- 98~99번째 줄 -->
+<p id="pwConfirmErrorText">The confirmation of your password is
+    different from your original password</p>                          <!-- 142~144번째 줄 -->
+<p id="nameErrorText">Please enter your last name.</p>                 <!-- 176번째 줄 -->
+<p id="phoneErrorText">Please enter a valid phone number.</p>          <!-- 210번째 줄 -->
+```
+
+**왜 개선하면 좋을까?**
+
+나머지 UI는 모두 한국어인데, 에러 메시지만 영어예요. 한국어 사이트를 이용하는 사용자가 갑자기 영어 에러 메시지를 보면 혼란스러워요. **언어 일관성**은 사용자 경험(UX)의 기본이에요.
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<p id="pwErrorText">Password is not acceptable</p>
+<p id="pwConfirmErrorText">The confirmation of your password is different from your original password</p>
+<p id="nameErrorText">Please enter your last name.</p>
+<p id="phoneErrorText">Please enter a valid phone number.</p>
+
+<!-- 수정 후 -->
+<p id="pwErrorText">비밀번호 형식이 올바르지 않아요.</p>
+<p id="pwConfirmErrorText">비밀번호가 일치하지 않아요.</p>
+<p id="nameErrorText">이름을 입력해주세요.</p>
+<p id="phoneErrorText">올바른 휴대폰 번호를 입력해주세요.</p>
+```
+
+---
+
+### 3-9. 테마에 정의되지 않은 색상을 UI 컴포넌트에서 사용해요 (중요도: 중간)
+
+**현재 상태:**
+
+```js
+// src/components/ui/badge.js 3~4번째 줄
+const badgeClass = {
+  SALE: "bg-burnt-orange text-white",   // ← burnt-orange 정의 안 됨!
+  BEST: "bg-teal-green text-white",     // ← teal-green 정의 안 됨!
+};
+
+// src/components/ui/product-card.js 94번째 줄
+discountRateEl.className = "text-sm text-burnt-orange font-semibold";  // ← 여기도!
+```
+
+```js
+// src/components/ui/product-card.js 16번째 줄
+card.className = "... bg-gradient-to-b from-grey-96 to-grey-94";  // ← grey-94 정의 안 됨!
+```
+
+**왜 개선하면 좋을까?**
+
+`style.css`의 `@theme`에 `--color-burnt-orange`, `--color-teal-green`, `--color-grey-94`가 정의되어 있지 않아요. Tailwind는 정의되지 않은 색상 클래스를 **무시**하기 때문에, SALE 배지의 배경색이 안 나오고, 할인율 글자색도 기본색으로 보여요.
+
+**추천:**
+
+`src/styles/style.css`의 `@theme`에 빠진 색상을 추가하세요:
+
+```css
+@theme {
+  /* 기존 색상들... */
+
+  /* UI 컴포넌트에서 사용하는 색상 추가 */
+  --color-burnt-orange: #cc5500;   /* 디자인 시안에서 정확한 값을 확인하세요 */
+  --color-teal-green: #2a9d8f;     /* 디자인 시안에서 정확한 값을 확인하세요 */
+  --color-grey-94: #f0f0f0;        /* 디자인 시안에서 정확한 값을 확인하세요 */
+  --color-dark-woody: #2d1f21;     /* button.js의 hover:bg-dark-woody용 */
+}
+```
+
+---
+
+### 3-10. 로그인에서 회원가입 링크 경로가 틀려요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/login/index.html 101번째 줄 -->
+<a href="/src/pages/signup/signup.html">회원가입</a>
+```
+
+**왜 개선하면 좋을까?**
+
+회원가입 페이지 파일은 `/src/pages/signup/index.html`인데, 링크는 `/src/pages/signup/signup.html`을 가리키고 있어요. 클릭하면 **404 에러(페이지를 찾을 수 없음)**가 나요!
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<a href="/src/pages/signup/signup.html">회원가입</a>
+
+<!-- 수정 후 -->
+<a href="/src/pages/signup/">회원가입</a>
+```
+
+---
+
+### 3-11. `<body>` 스타일이 페이지마다 달라요 (중요도: 중간)
+
+**현재 상태:**
+
+```html
+<!-- index.html -->
+<body class="bg-gray-50 text-gray-900">          <!-- Tailwind 기본 색상 -->
+
+<!-- src/pages/login/index.html -->
+<body>                                            <!-- 클래스 없음 -->
+
+<!-- src/pages/signup/index.html -->
+<body class="bg-grey-99">                         <!-- 커스텀 색상 -->
+
+<!-- src/pages/product/detail/index.html -->
+<body>                                            <!-- 클래스 없음 -->
+```
+
+**왜 개선하면 좋을까?**
+
+4개의 페이지가 각각 다른 `<body>` 스타일을 가지고 있어요:
+- `index.html`: Tailwind 기본 `gray-50` (연한 회색)
+- `login`: 클래스 없음 → `@layer base`의 `spring-wood` 적용
+- `signup`: 커스텀 `grey-99` (거의 흰색)
+- `product/detail`: 클래스 없음 → `@layer base`의 `spring-wood` 적용
+
+사용자가 페이지를 이동할 때 **배경색이 갑자기 바뀌면** 어색해요. 특히 `index.html`의 `bg-gray-50`은 `@layer base`에서 설정한 `bg-spring-wood`와 **다른 색상**이에요.
+
+**추천:**
+
+`@layer base`에서 이미 body 스타일을 정의하고 있으니, 모든 페이지에서 `<body>` 클래스를 통일하세요:
+
+```html
+<!-- 모든 페이지에서 이렇게 -->
+<body>
+  <!-- @layer base의 bg-spring-wood, text-woody-brown이 자동 적용돼요 -->
+```
+
+`index.html`의 `class="bg-gray-50 text-gray-900"`을 제거하고, `signup`의 `class="bg-grey-99"`도 제거하세요.
+
+---
+
+### 3-12. 상품 상세 페이지의 `<title>`이 "Document"예요 (중요도: 낮음)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/product/detail/index.html 6번째 줄 -->
+<title>Document</title>
+```
+
+**왜 개선하면 좋을까?**
+
+브라우저 탭에 "Document"라고 표시돼요. 사용자가 탭을 여러 개 열었을 때 어떤 탭이 어떤 페이지인지 구분할 수 없어요. 검색 엔진도 `<title>` 태그를 검색 결과 제목으로 사용해요.
+
+**추천:**
+
+```html
+<!-- 수정 전 -->
+<title>Document</title>
+
+<!-- 수정 후 -->
+<title>상품 상세 | L'OcciShop</title>
+```
+
+---
+
+### 3-13. 회원가입 "주소" 필드에 `required`가 붙어 있어요 (중요도: 낮음)
+
+**현재 상태:**
+
+```html
+<!-- src/pages/signup/index.html 214~224번째 줄 -->
+<label for="userAddress" class="...">주소</label>      <!-- 별표(*)가 없음 = 선택 항목 -->
+<input type="text" id="userAddress" ... required />     <!-- 그런데 required가 있어요! -->
+```
+
+"상세주소" 필드(248~253번째 줄)도 마찬가지예요.
+
+**왜 개선하면 좋을까?**
+
+라벨에 `*`(별표)가 없으므로 선택 항목으로 보이는데, `required` 속성 때문에 **필수 입력**으로 동작해요. 사용자는 "주소는 안 써도 되겠지?"라고 생각하고 제출하면 에러가 나서 혼란스러워해요.
+
+**추천:** 둘 중 하나를 선택하세요:
+
+```html
+<!-- 방법 A: 진짜 선택 항목이면 required 제거 -->
+<input type="text" id="userAddress" name="userAddress" class="..." />
+
+<!-- 방법 B: 필수 항목이면 라벨에 별표 추가 -->
+<label for="userAddress">주소*</label>
+<input type="text" id="userAddress" name="userAddress" class="..." required />
+```
+
+---
+
+### 3-14. index.js의 역할이 너무 많아요 — 응집도를 높이면 좋겠어요 (중요도: 낮음)
+
+**현재 상태:**
+
+```js
+// src/pages/product/detail/index.js — 이 하나의 파일이 하는 일:
+async function initProductPage() {
+  // 1. HTML 파일 로딩 (fetch)
+  // 2. 배지 생성 및 교체
+  // 3. 장바구니 버튼 생성 및 이벤트 바인딩
+  // 4. 상세 정보 HTML 로딩
+  // 5. 드로어 3개 생성 및 이벤트 바인딩
+}
+```
+
+**왜 개선하면 좋을까?**
+
+이 파일은 지금 5가지 일을 하고 있어요. 지금은 코드 양이 적어서 괜찮지만, 상품 데이터를 API에서 가져오고, 리뷰를 표시하고, 옵션 선택 기능을 추가하면 이 파일이 **100줄, 200줄, 300줄...** 으로 계속 커질 거예요.
+
+**응집도(Cohesion)**란 "하나의 모듈이 하나의 목적에 집중하는 정도"예요. 지금 `index.js`는 여러 목적이 섞여 있어서 응집도가 낮아요.
+
+**결합도(Coupling)**란 "모듈 사이의 의존 관계"예요. `index.js`가 badge, button, drawer, HTML 파일을 모두 직접 다루고 있어서 결합도가 높아요.
+
+**추천:** 기능별로 함수를 분리하세요 (지금 당장은 아니더라도, 코드가 커질 때):
+
+```js
+// 지금 구조 (모든 것이 한 함수에)
+async function initProductPage() {
+  // HTML 로딩 + 배지 + 버튼 + 드로어 전부 여기에...
+}
+
+// 더 좋은 구조 (역할별로 분리)
+function initBadge() { /* 배지 관련 코드만 */ }
+function initCartButton() { /* 장바구니 버튼 코드만 */ }
+function initDrawers() { /* 드로어 관련 코드만 */ }
+
+async function initProductPage() {
+  await loadHTML();     // HTML 로딩만
+  initBadge();          // 배지 초기화만
+  initCartButton();     // 장바구니만
+  initDrawers();        // 드로어만
+}
+```
+
+이렇게 하면 "장바구니 버튼에 버그가 있다" → `initCartButton()` 함수만 보면 돼요!
+
+---
+
+## 4. 파일별 요약
+
+| 파일 | 완성도 | 주요 피드백 |
+|------|--------|-------------|
+| `index.html` | 80% | 시맨틱 태그 좋음. `<body>` 클래스 통일 필요 |
+| `vite.config.js` | 50% | 빌드 경로 오류, 누락된 페이지 추가 필요 |
+| `src/styles/style.css` | 70% | `#7E717` 오류, `--color--grey-99` 중복, 빠진 색상 다수 |
+| `src/js/main.js` | 50% | CSS import만 있음 |
+| `src/pages/login/index.html` | 60% | 접근성 좋음. 반응형/버튼색/회원가입 링크 수정 필요 |
+| `src/pages/signup/index.html` | 55% | 접근성 좋음. 아이콘 hidden 누락, 영어 메시지, required 불일치 |
+| `src/pages/product/detail/index.html` | 60% | 시맨틱 좋음. title 수정 필요 |
+| `src/pages/product/detail/index.js` | 75% | 컴포넌트 활용 좋음. 함수 분리하면 더 좋아요 |
+| `detail-main.html` | 70% | 시맨틱 좋음. alt 속성, id 공백 수정 필요 |
+| `detail-info.html` | 65% | 큰따옴표 중복 오류 수정 필요 |
+| `src/components/ui/badge.js` | 80% | 구조 좋음. 미정의 색상 추가 필요 |
+| `src/components/ui/button.js` | 90% | variant/size 패턴 훌륭! |
+| `src/components/ui/drawer.js` | 90% | 애니메이션 처리 세련됨! |
+| `src/components/ui/product-card.js` | 75% | 구조 좋음. 미정의 색상 추가 필요 |
+| `src/components/ui/tag.js` | 90% | 깔끔한 구조! |
+| `.gitignore` | 40% | package.json 제외 문제 심각 |
+
+---
+
+## 5. 다음 단계 제안
+
+1. **`.gitignore`에서 `package-lock.json` 줄 삭제** — 프로젝트 협업의 기반! (1분)
+2. **`vite.config.js` 빌드 경로 수정** — 배포가 안 되는 치명적 문제 (3분)
+3. **`detail-info.html` 큰따옴표 중복 수정** — 단순 오타 (1분)
+4. **로그인 버튼 `bg--woody-brown` → `bg-woody-brown` 수정** — 단순 오타 (1분)
+5. **`style.css`에 빠진 색상 변수 추가** — UI 컴포넌트가 제대로 표시되려면 필수 (5분)
+6. **이전 리뷰 미해결 항목 정리** — `#7E717`, `--color--grey-99`, 중복 변수 (5분)
+7. **회원가입 아이콘/메시지에 `hidden` 추가** — 사용자 경험 개선 (10분)
+8. **회원가입 에러 메시지 한국어로 통일** — 언어 일관성 (5분)
+9. **이미지 `alt` 속성 채우기** — 접근성 개선 (5분)
+10. **로그인/회원가입 JS 기능 구현** — 폼 유효성 검사 및 API 연동 (30분+)
+
+---
+
+## 6. 마무리
+
+이전 리뷰 때와 비교하면 프로젝트가 **눈에 띄게 성장**했어요!
+
+특히 인상적인 점:
+- **UI 컴포넌트 시스템을 직접 만든 것!** — badge, button, drawer, tag, product-card. 실무에서 디자인 시스템을 만드는 과정과 비슷해요. 각 컴포넌트가 하나의 역할에 집중하고(높은 응집도), 독립적으로 사용할 수 있게(낮은 결합도) 설계한 것이 훌륭해요.
+- **시맨틱 HTML을 잘 활용한 것!** — `<article>`, `<figure>`, `<section>`, `<header>`, `<label for="...">` 등이 적절하게 사용되고 있어요.
+- **프로젝트 구조가 체계적인 것!** — `pages/`, `components/ui/`, `assets/` 로 역할별로 잘 나눠져 있어요.
+
+대부분의 개선 항목은 오타나 누락으로 인한 것이고, **설계 방향 자체는 아주 좋아요!** 클래스명의 하이픈 실수, 색상 변수 누락 같은 것은 누구나 할 수 있는 실수에요. 중요한 것은 이런 실수를 찾고 고쳐나가는 과정이고, 여러분은 그것을 잘 해내고 있어요.
+
+다음 리뷰 때 로그인/회원가입의 JavaScript 기능(폼 검증, API 연동)이 완성된 모습을 보고 싶어요. 지금 속도라면 분명 잘 해낼 거예요. 파이팅!

--- a/reviews/2026040614_리뷰_해결.md
+++ b/reviews/2026040614_리뷰_해결.md
@@ -1,0 +1,668 @@
+# 리뷰 해결 가이드
+
+> 리뷰 날짜: 2026-04-06
+> 대상: L'OcciShop 클론 프로젝트 (록시땅 쇼핑몰 클론)
+> 원본 리뷰: [2026040614_리뷰.md](./2026040614_리뷰.md)
+> 이전 해결 가이드: [2026040314_리뷰_해결.md](./2026040314_리뷰_해결.md)
+
+---
+
+## 3-1. `.gitignore`에서 `package.json`과 `package-lock.json` 제외 문제 (중요도: 높음)
+
+### 문제
+
+`.gitignore` 27~28번째 줄에서 `packge.json`(오타)과 `package-lock.json`이 Git 추적에서 제외되고 있어요.
+
+### 해결 방법
+
+**Step 1.** `.gitignore` 파일을 열고 27~28번째 줄을 삭제하세요.
+
+```gitignore
+# 수정 전 (.gitignore 27~28번째 줄)
+packge.json
+package-lock.json
+
+# 수정 후 — 위 두 줄을 완전히 삭제하세요!
+```
+
+**Step 2.** `package-lock.json`이 이미 `.gitignore`에 의해 무시되고 있으므로, 다시 추적하도록 해주세요.
+
+```bash
+# 터미널에서 실행
+git add --force package-lock.json
+git commit -m "fix: package-lock.json을 Git 추적에 다시 포함"
+```
+
+> **쉽게 말하면:** `package.json`은 레시피(어떤 재료가 필요한지), `package-lock.json`은 정확한 재료 목록(어떤 브랜드의 몇 g인지)이에요. 이 두 파일이 없으면 다른 사람이 같은 요리를 만들 수 없어요!
+
+---
+
+## 3-2. `vite.config.js` 빌드 경로 수정 (중요도: 높음)
+
+### 문제
+
+`vite.config.js` 15번째 줄에서 `src/pages/product-detail.html`을 참조하지만, 실제 파일은 `src/pages/product/detail/index.html`에 있어요. 로그인과 회원가입 페이지도 빌드 설정에 빠져 있어요.
+
+### 해결 방법
+
+**Step 1.** `vite.config.js`를 열고 `build.rollupOptions.input`을 수정하세요.
+
+```js
+// 수정 전 (vite.config.js 13~18번째 줄)
+build: {
+  rollupOptions: {
+    input: {
+      main: resolve(__dirname, "index.html"),
+      productDetail: resolve(__dirname, "src/pages/product-detail.html"),
+    },
+  },
+},
+
+// 수정 후
+build: {
+  rollupOptions: {
+    input: {
+      main: resolve(__dirname, "index.html"),
+      login: resolve(__dirname, "src/pages/login/index.html"),
+      signup: resolve(__dirname, "src/pages/signup/index.html"),
+      productDetail: resolve(__dirname, "src/pages/product/detail/index.html"),
+    },
+  },
+},
+```
+
+**Step 2.** 수정 후 빌드가 되는지 확인하세요.
+
+```bash
+npm run build
+```
+
+에러 없이 `dist/` 폴더가 생기면 성공이에요!
+
+> **쉽게 말하면:** 택배 보낼 때 주소가 틀리면 배달이 안 되잖아요. 파일 경로도 정확해야 빌드(배달)가 돼요!
+
+---
+
+## 3-3. `detail-info.html` 큰따옴표 중복 수정 (중요도: 높음)
+
+### 문제
+
+`src/pages/product/detail/components/detail-info.html`의 16번째 줄과 23번째 줄에서 `class` 속성 끝에 큰따옴표가 두 개(`""`) 있어요.
+
+### 해결 방법
+
+**Step 1.** `detail-info.html`을 열고 16번째 줄을 수정하세요.
+
+```html
+<!-- 수정 전 (16번째 줄) -->
+<button
+  id="ingredients"
+  class="flex justify-between items-center w-full px-3 py-2.5 rounded-sm leading-5 text-sm bg-merino hover:bg-cararra""
+>
+
+<!-- 수정 후 — 맨 끝 큰따옴표 하나 제거 -->
+<button
+  id="ingredients"
+  class="flex justify-between items-center w-full px-3 py-2.5 rounded-sm leading-5 text-sm bg-merino hover:bg-cararra"
+>
+```
+
+**Step 2.** 23번째 줄도 같은 방식으로 수정하세요.
+
+```html
+<!-- 수정 전 (23번째 줄) -->
+<button
+  id="productDisclosure"
+  class="flex justify-between items-center w-full px-3 py-2.5 rounded-sm leading-5 text-sm bg-merino hover:bg-cararra""
+>
+
+<!-- 수정 후 -->
+<button
+  id="productDisclosure"
+  class="flex justify-between items-center w-full px-3 py-2.5 rounded-sm leading-5 text-sm bg-merino hover:bg-cararra"
+>
+```
+
+VS Code에서 찾기(`Ctrl+H` / `Cmd+H`):
+- 찾기: `cararra""`
+- 바꾸기: `cararra"`
+
+> **쉽게 말하면:** 문장 끝에 마침표를 두 개 찍으면 어색하잖아요.. (이것처럼요!) 따옴표도 하나만 있어야 해요.
+
+---
+
+## 3-4. 로그인 버튼 `bg--woody-brown` 수정 (중요도: 높음)
+
+### 문제
+
+`src/pages/login/index.html` 97번째 줄의 로그인 버튼에서 `bg--woody-brown`(하이픈 두 개)으로 되어 있어서 배경색이 적용되지 않아요.
+
+### 해결 방법
+
+**Step 1.** `src/pages/login/index.html`을 열고 97번째 줄을 수정하세요.
+
+```html
+<!-- 수정 전 (97번째 줄) -->
+<button
+  type="submit"
+  class="w-60 h-10 bg--woody-brown text-white-solid text-[14px] font-medium leading-6 mt-4"
+>
+
+<!-- 수정 후 — bg- 뒤의 하이픈 하나 제거 -->
+<button
+  type="submit"
+  class="w-60 h-10 bg-woody-brown text-white-solid text-[14px] font-medium leading-6 mt-4"
+>
+```
+
+> **쉽게 말하면:** 전화번호에 `-`를 하나 더 넣으면 전화가 안 걸리는 것처럼, CSS 클래스 이름도 정확해야 스타일이 적용돼요!
+
+---
+
+## 3-5. 상품 이미지 `alt` 속성 보강 (중요도: 중간)
+
+### 문제
+
+`src/pages/product/detail/components/detail-main.html`의 상품 이미지 8개 모두 `alt=""`이고, 별점 아이콘 5개는 `alt` 속성 자체가 없어요.
+
+### 해결 방법
+
+**Step 1.** 메인 이미지와 서브 이미지에 설명을 넣으세요.
+
+```html
+<!-- 수정 전 (7번째 줄) -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="" />
+
+<!-- 수정 후 -->
+<img class="bg-merino" src="/src/assets/images/product1_0.webp" alt="상품 메인 이미지" />
+```
+
+서브 이미지들도:
+```html
+<!-- 수정 전 -->
+<li><img class="bg-merino" src="/src/assets/images/product1_1.webp" alt="" /></li>
+
+<!-- 수정 후 -->
+<li><img class="bg-merino" src="/src/assets/images/product1_1.webp" alt="상품 상세 이미지 1" /></li>
+<li><img class="bg-merino" src="/src/assets/images/product1_2.webp" alt="상품 상세 이미지 2" /></li>
+<!-- ... 나머지도 번호를 매겨주세요 -->
+```
+
+**Step 2.** 별점 아이콘은 장식용이므로 빈 `alt`를 넣고 스크린리더에서 숨겨주세요.
+
+```html
+<!-- 수정 전 (73~77번째 줄) -->
+<div id="rating-stars" class="flex">
+  <img src="/src/assets/icon/star.svg" />
+  <img src="/src/assets/icon/star.svg" />
+  <img src="/src/assets/icon/star.svg" />
+  <img src="/src/assets/icon/star.svg" />
+  <img src="/src/assets/icon/star.svg" />
+</div>
+
+<!-- 수정 후 — role과 aria-label로 별점 정보를 한 번에 전달 -->
+<div id="rating-stars" class="flex" role="img" aria-label="별점 5점 만점에 5점">
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+  <img src="/src/assets/icon/star.svg" alt="" aria-hidden="true" />
+</div>
+```
+
+> **쉽게 말하면:** 눈을 감고 쇼핑한다고 상상해보세요. "이미지"라고만 들리면 뭔지 모르잖아요. "상품 메인 이미지"라고 알려줘야 해요!
+
+---
+
+## 3-6. `detail-main.html` id 공백 제거 (중요도: 중간)
+
+### 문제
+
+`src/pages/product/detail/components/detail-main.html` 5번째 줄에서 `id="product-gallery "` 끝에 공백이 있어요.
+
+### 해결 방법
+
+**Step 1.** 5번째 줄에서 공백을 제거하세요.
+
+```html
+<!-- 수정 전 (5번째 줄) -->
+<figure id="product-gallery " class="flex flex-col gap-2 w-[60%] max-w-182">
+
+<!-- 수정 후 — "product-gallery" 뒤의 공백 제거 -->
+<figure id="product-gallery" class="flex flex-col gap-2 w-[60%] max-w-182">
+```
+
+> **쉽게 말하면:** 택배 송장에 이름 뒤에 빈칸이 들어가면 배송 조회가 안 될 수 있는 것처럼, id에 공백이 있으면 JavaScript에서 찾을 때 문제가 생겨요!
+
+---
+
+## 3-7. 회원가입 아이콘/메시지에 `hidden` 추가 (중요도: 중간)
+
+### 문제
+
+`src/pages/signup/index.html`에서 에러 아이콘, 통과 아이콘, 에러 메시지가 페이지 로딩 시부터 모두 보여요.
+
+### 해결 방법
+
+모든 에러/통과 아이콘과 에러 메시지에 `hidden` 클래스를 추가해야 해요. 파일에서 수정할 곳이 많으니 **VS Code 찾기/바꾸기**를 활용하세요.
+
+**Step 1.** 아이디 필드의 아이콘과 메시지 (32~51번째 줄)
+
+```html
+<!-- 수정 전 (36번째 줄) -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idErrorIcon" />
+
+<!-- 수정 후 — hidden 추가 -->
+<img src="/src/assets/icon/error.svg" alt="아이디 에러"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 hidden"
+     id="idErrorIcon" />
+```
+
+```html
+<!-- 수정 전 (40번째 줄) -->
+<img src="/src/assets/icon/check.svg" alt="아이디 통과"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4"
+     id="idCheckIcon" />
+
+<!-- 수정 후 -->
+<img src="/src/assets/icon/check.svg" alt="아이디 통과"
+     class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 hidden"
+     id="idCheckIcon" />
+```
+
+```html
+<!-- 수정 전 (46~51번째 줄) -->
+<p class="text-error-red text-[12px] font-medium leading-4 mb-4"
+   id="idErrorText">
+  잘못된 형식입니다.
+</p>
+
+<!-- 수정 후 — hidden 추가 -->
+<p class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden"
+   id="idErrorText">
+  잘못된 형식입니다.
+</p>
+```
+
+**Step 2.** 나머지 필드도 같은 방식으로 수정하세요.
+
+수정할 요소 목록 (모두 `hidden` 추가):
+
+| 요소 ID | 줄 번호 (대략) | 유형 |
+|---------|---------------|------|
+| `idErrorIcon` | 36 | 에러 아이콘 |
+| `idCheckIcon` | 40 | 통과 아이콘 |
+| `idErrorText` | 46 | 에러 메시지 |
+| `pwErrorIcon` | 70 | 에러 아이콘 |
+| `pwCheckIcon` | 75 | 통과 아이콘 |
+| `pwGuideText` | 90 | - (이건 가이드니까 보여도 돼요!) |
+| `pwErrorText` | 96 | 에러 메시지 |
+| `pwConfirmErrorIcon` | 120 | 에러 아이콘 |
+| `pwConfirmCheckIcon` | 125 | 통과 아이콘 |
+| `pwConfirmErrorText` | 139 | 에러 메시지 |
+| `nameErrorIcon` | 160 | 에러 아이콘 |
+| `nameCheckIcon` | 165 | 통과 아이콘 |
+| `nameErrorText` | 173 | 에러 메시지 |
+| `phoneErrorIcon` | 196 | 에러 아이콘 |
+| `phoneCheckIcon` | 201 | 통과 아이콘 |
+| `phoneErrorText` | 208 | 에러 메시지 |
+| `addressErrorIcon` | 229 | 에러 아이콘 |
+| `addressCheckIcon` | 234 | 통과 아이콘 |
+| `detailAddressErrorIcon` | 256 | 에러 아이콘 |
+| `detailAddressCheckIcon` | 261 | 통과 아이콘 |
+
+**팁:** JavaScript에서 유효성 검사 후 아이콘을 보여줄 때는 이렇게 하면 돼요:
+
+```js
+// 에러 표시
+document.getElementById("idErrorIcon").classList.remove("hidden");
+document.getElementById("idErrorText").classList.remove("hidden");
+
+// 통과 표시
+document.getElementById("idCheckIcon").classList.remove("hidden");
+document.getElementById("idErrorIcon").classList.add("hidden");
+```
+
+> **쉽게 말하면:** 시험지를 나눠주면서 동시에 "오답!" 도장을 찍어놓으면 안 되잖아요. 학생이 답을 쓴 다음에 채점해야 해요!
+
+---
+
+## 3-8. 회원가입 에러 메시지 한국어로 통일 (중요도: 중간)
+
+### 문제
+
+`src/pages/signup/index.html`에서 일부 에러 메시지가 영어로 되어 있어요.
+
+### 해결 방법
+
+**Step 1.** 아래 4군데를 한국어로 변경하세요.
+
+```html
+<!-- 수정 전 (98~99번째 줄) -->
+<p id="pwErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4">
+  Password is not acceptable
+</p>
+
+<!-- 수정 후 -->
+<p id="pwErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden">
+  비밀번호 형식이 올바르지 않아요.
+</p>
+```
+
+```html
+<!-- 수정 전 (142~144번째 줄) -->
+<p id="pwConfirmErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4">
+  The confirmation of your password is different from your original password
+</p>
+
+<!-- 수정 후 -->
+<p id="pwConfirmErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden">
+  비밀번호가 일치하지 않아요.
+</p>
+```
+
+```html
+<!-- 수정 전 (176번째 줄) -->
+<p id="nameErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4">
+  Please enter your last name.
+</p>
+
+<!-- 수정 후 -->
+<p id="nameErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden">
+  이름을 입력해주세요.
+</p>
+```
+
+```html
+<!-- 수정 전 (210번째 줄) -->
+<p id="phoneErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4">
+  Please enter a valid phone number.
+</p>
+
+<!-- 수정 후 -->
+<p id="phoneErrorText" class="text-error-red text-[12px] font-medium leading-4 mb-4 hidden">
+  올바른 휴대폰 번호를 입력해주세요.
+</p>
+```
+
+> **쉽게 말하면:** 한국어 안내서 중간에 갑자기 영어가 나오면 "잉?" 하잖아요. 사용자 입장에서 모든 안내가 같은 언어로 나와야 자연스러워요!
+
+---
+
+## 3-9. 테마에 빠진 색상 변수 추가 (중요도: 중간)
+
+### 문제
+
+`badge.js`, `button.js`, `product-card.js`에서 사용하는 색상이 `style.css`의 `@theme`에 정의되어 있지 않아서 해당 색상이 적용되지 않아요.
+
+### 해결 방법
+
+**Step 1.** `src/styles/style.css`의 `@theme` 블록에 아래 색상을 추가하세요.
+
+```css
+/* 수정 전 (src/styles/style.css) */
+@theme {
+  /* 기존 색상들... */
+  --color-orange-90: #e8e4e2;
+}
+
+/* 수정 후 — 아래 색상들을 @theme 블록 안에 추가 */
+@theme {
+  /* 기존 색상들... */
+  --color-orange-90: #e8e4e2;
+
+  /* UI 컴포넌트용 색상 (디자인 시안에서 정확한 값을 확인해주세요!) */
+  --color-burnt-orange: #cc5500;    /* badge.js SALE, product-card.js 할인율 */
+  --color-teal-green: #2a9d8f;     /* badge.js BEST */
+  --color-grey-94: #f0f0f0;        /* product-card.js 카드 그라데이션 */
+  --color-dark-woody: #2d1f21;     /* button.js hover 색상 */
+}
+```
+
+**Step 2.** 디자인 시안(Figma 등)에서 정확한 색상값을 확인하세요. 위의 값은 임시값이에요!
+
+> **쉽게 말하면:** 레고를 조립하는데 설명서에 "빨간 블록을 끼우세요"라고 하는데 상자에 빨간 블록이 없으면 완성할 수 없잖아요. CSS 변수가 그 블록이에요!
+
+---
+
+## 3-10. 로그인 → 회원가입 링크 경로 수정 (중요도: 중간)
+
+### 문제
+
+`src/pages/login/index.html` 101번째 줄에서 회원가입 링크가 존재하지 않는 파일을 가리키고 있어요.
+
+### 해결 방법
+
+**Step 1.** 링크 경로를 수정하세요.
+
+```html
+<!-- 수정 전 (101번째 줄) -->
+<a href="/src/pages/signup/signup.html">회원가입</a>
+
+<!-- 수정 후 -->
+<a href="/src/pages/signup/">회원가입</a>
+```
+
+> **쉽게 말하면:** 내비게이션에 잘못된 주소를 넣으면 목적지에 도착할 수 없잖아요!
+
+---
+
+## 3-11. `<body>` 스타일 통일 (중요도: 중간)
+
+### 문제
+
+4개 페이지의 `<body>` 스타일이 각각 달라서, 페이지 이동 시 배경색이 바뀌어요.
+
+### 해결 방법
+
+**Step 1.** `index.html`의 `<body>` 클래스를 제거하세요.
+
+```html
+<!-- 수정 전 (index.html 9번째 줄) -->
+<body class="bg-gray-50 text-gray-900">
+
+<!-- 수정 후 -->
+<body>
+```
+
+**Step 2.** `signup/index.html`의 `<body>` 클래스도 제거하세요.
+
+```html
+<!-- 수정 전 (signup/index.html 9번째 줄) -->
+<body class="bg-grey-99">
+
+<!-- 수정 후 -->
+<body>
+```
+
+이렇게 하면 모든 페이지에서 `@layer base`의 기본 스타일(`bg-spring-wood text-woody-brown`)이 적용돼요.
+
+**Step 3.** 만약 회원가입 페이지만 배경색이 달라야 한다면, `<body>` 대신 `<main>` 태그에 배경색을 넣으세요.
+
+```html
+<body>
+  <main class="bg-grey-99 flex justify-center items-center">
+```
+
+> **쉽게 말하면:** 방마다 벽지가 제각각이면 집이 어수선해 보여요. 기본 벽지를 통일하고, 특별한 방만 따로 꾸미세요!
+
+---
+
+## 3-12. 상품 상세 `<title>` 수정 (중요도: 낮음)
+
+### 문제
+
+`src/pages/product/detail/index.html` 6번째 줄의 `<title>`이 기본값 "Document"예요.
+
+### 해결 방법
+
+```html
+<!-- 수정 전 (6번째 줄) -->
+<title>Document</title>
+
+<!-- 수정 후 -->
+<title>상품 상세 | L'OcciShop</title>
+```
+
+> **쉽게 말하면:** 브라우저 탭에 "Document"라고 표시되면 "이게 뭐지?" 하잖아요. 페이지 이름표를 달아주세요!
+
+---
+
+## 3-13. 회원가입 "주소" 필드 `required` 수정 (중요도: 낮음)
+
+### 문제
+
+`src/pages/signup/index.html` 224번째 줄과 253번째 줄의 "주소"와 "상세주소" 입력란에 `required`가 있는데, 라벨에는 `*`(필수 표시)가 없어요.
+
+### 해결 방법
+
+**방법 A: 선택 항목으로 처리** (추천)
+
+```html
+<!-- 수정 전 (224번째 줄) -->
+<input type="text" id="userAddress" name="userAddress"
+       class="bg-grey-96 border border-grey-45 ..."
+       required />
+
+<!-- 수정 후 — required 제거 -->
+<input type="text" id="userAddress" name="userAddress"
+       class="bg-grey-96 border border-grey-45 ..." />
+```
+
+상세주소(253번째 줄)도 같은 방식으로 `required`를 제거하세요.
+
+**방법 B: 필수 항목으로 처리**
+
+```html
+<!-- 수정 전 (214번째 줄) -->
+<label for="userAddress" class="...">주소</label>
+
+<!-- 수정 후 — 별표 추가 -->
+<label for="userAddress" class="...">주소*</label>
+```
+
+> **쉽게 말하면:** 시험지에 "선택 문제"라고 써놓고 안 풀면 감점하면 학생이 억울하잖아요. 필수면 필수라고, 선택이면 선택이라고 정확히 알려줘야 해요!
+
+---
+
+## 3-14. `index.js` 함수 분리로 응집도 높이기 (중요도: 낮음)
+
+### 문제
+
+`src/pages/product/detail/index.js`의 `initProductPage()` 함수가 HTML 로딩, 배지 생성, 버튼 생성, 드로어 생성 등 5가지 역할을 동시에 해요.
+
+### 해결 방법
+
+지금 당장 수정하지 않아도 되지만, 코드가 더 커질 때 이렇게 분리하면 좋아요.
+
+**Step 1.** 기능별로 함수를 분리하세요.
+
+```js
+// 수정 전 (현재 index.js)
+async function initProductPage() {
+  const container = document.querySelector("#detail-main");
+  if (!container) return;
+
+  // 60줄이 넘는 코드가 한 함수에...
+  const res = await fetch("...");
+  container.innerHTML = await res.text();
+  const badge = createBadge({ type: "NEW" });
+  // ...장바구니 버튼...
+  // ...드로어 3개...
+}
+
+// 수정 후 — 역할별로 분리
+import { createButton } from "/src/components/ui/button.js";
+import { createBadge } from "/src/components/ui/badge.js";
+import { createDrawer } from "/src/components/ui/drawer.js";
+
+/** HTML 파일을 로드해서 컨테이너에 삽입 */
+async function loadHTML(selector, url) {
+  const container = document.querySelector(selector);
+  if (!container) return;
+  const res = await fetch(url);
+  container.innerHTML = await res.text();
+}
+
+/** 배지 초기화 */
+function initBadge() {
+  const badge = createBadge({ type: "NEW" });
+  document.querySelector("#badge").replaceWith(badge);
+}
+
+/** 장바구니 버튼 초기화 */
+function initCartButton() {
+  const cartBtn = createButton({
+    text: "장바구니에 추가",
+    variant: "primary",
+    size: "md",
+    fullWidth: true,
+  });
+  cartBtn.addEventListener("click", () => {
+    console.log("장바구니 추가!");
+  });
+  document.querySelector("#cart-button").append(cartBtn);
+}
+
+/** 드로어 초기화 */
+function initDrawers() {
+  const drawers = [
+    { title: "사용 방법", btnId: "#howToUse", content: "<p>사용 방법 내용</p>" },
+    { title: "원료", btnId: "#ingredients", content: "<p>원료 내용</p>" },
+    { title: "상품정보 제공고시", btnId: "#productDisclosure", content: "<p>상품정보 내용</p>" },
+  ];
+
+  drawers.forEach(({ title, btnId, content }) => {
+    const drawer = createDrawer({ title, position: "right" });
+    drawer.content.innerHTML = content;
+    document.querySelector(btnId).addEventListener("click", () => {
+      drawer.open();
+    });
+  });
+}
+
+/** 메인 초기화 함수 — 각 역할을 호출만 해요 */
+async function initProductPage() {
+  await loadHTML("#detail-main", "/src/pages/product/detail/components/detail-main.html");
+  initBadge();
+  initCartButton();
+
+  await loadHTML("#product-info", "/src/pages/product/detail/components/detail-info.html");
+  initDrawers();
+}
+
+document.addEventListener("DOMContentLoaded", initProductPage);
+```
+
+이렇게 분리하면:
+- **응집도 UP**: 각 함수가 하나의 역할만 해요
+- **결합도 DOWN**: 드로어를 수정할 때 `initDrawers()`만 보면 돼요
+- **가독성 UP**: `initProductPage()`를 읽으면 전체 흐름이 한눈에 보여요
+- **테스트 쉬움**: 각 함수를 독립적으로 테스트할 수 있어요
+
+> **쉽게 말하면:** 요리할 때 "재료 손질", "볶기", "소스 만들기", "플레이팅"을 한 사람이 해도 되지만, 각 단계를 명확히 나누면 어디서 실수했는지 찾기 쉽고, 다른 요리에도 같은 소스를 쓸 수 있어요!
+
+---
+
+## 수정 우선순위 체크리스트
+
+| 순서 | 항목 | 난이도 | 예상 시간 |
+|------|------|--------|-----------|
+| 1 | 3-4. 로그인 버튼 `bg--woody-brown` 수정 | 쉬움 | 1분 |
+| 2 | 3-3. detail-info.html 큰따옴표 중복 | 쉬움 | 1분 |
+| 3 | 3-6. detail-main.html id 공백 제거 | 쉬움 | 1분 |
+| 4 | 3-12. 상품 상세 `<title>` 수정 | 쉬움 | 1분 |
+| 5 | 3-10. 회원가입 링크 경로 수정 | 쉬움 | 1분 |
+| 6 | 3-1. `.gitignore` 수정 | 쉬움 | 2분 |
+| 7 | 3-2. `vite.config.js` 빌드 경로 수정 | 쉬움 | 3분 |
+| 8 | 3-8. 에러 메시지 한국어 통일 | 쉬움 | 3분 |
+| 9 | 3-11. `<body>` 스타일 통일 | 쉬움 | 3분 |
+| 10 | 3-9. 테마 색상 변수 추가 | 보통 | 5분 |
+| 11 | 3-5. 상품 이미지 alt 속성 | 보통 | 5분 |
+| 12 | 3-13. 주소 필드 required 수정 | 쉬움 | 2분 |
+| 13 | 3-7. 회원가입 아이콘 hidden 추가 | 보통 | 10분 |
+| 14 | 3-14. index.js 함수 분리 | 도전 | 20분 |
+
+> 1~9번은 모두 합쳐도 15분이면 끝나는 간단한 수정이에요! 오늘 쉬운 것부터 하나씩 체크해나가면 프로젝트가 눈에 띄게 깔끔해질 거예요. UI 컴포넌트 시스템을 직접 만든 여러분의 실력이라면 충분히 해낼 수 있어요. 파이팅!


### PR DESCRIPTION
## Summary
- 3차 증분 코드 리뷰 문서 및 해결 가이드 추가 (`reviews/`, `docs/`)
- 신규 14개 개선 항목 발견 (높음 4 / 중간 6 / 낮음 4)
- 이전 리뷰 미해결 5건, 해결 2건 추적

## 주요 발견 사항
- `.gitignore`에서 `package-lock.json` 제외 → 팀 협업 문제
- `vite.config.js` 빌드 경로 오류 → 배포 불가
- HTML 오타 (따옴표 중복, id 공백, 클래스명 하이픈)
- 회원가입 에러 아이콘 `hidden` 누락
- 테마 미정의 색상 사용 (badge, product-card)

## Test plan
- [x] 리뷰 문서 마크다운 렌더링 확인
- [ ] 리뷰 항목별 수정 작업 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)