### PR TITLE
docs: 상품 추천 API (exclude, sort=rating, related sort)

### DIFF
--- a/docs/api/product_recommend_api.md
+++ b/docs/api/product_recommend_api.md
@@ -1,0 +1,100 @@
+# 상품 추천/관련 상품 API 가이드
+
+> 2026-04-07: 상품 목록에 `exclude`, `sort=rating` 파라미터가 추가되었습니다.
+
+---
+
+## 추천 상품 구현 방법
+
+상품 상세 페이지에서 같은 카테고리의 추천 상품을 보여주려면 두 가지 방법이 있습니다.
+
+### 방법 1: GET /products (추천)
+
+```
+GET /api/loccishop/v1/products?categoryId={카테고리ID}&exclude={현재상품ID}&sort=rating&limit=10
+```
+
+```javascript
+// 상품 상세 페이지에서 추천 상품 로드
+const productId = 5       // 현재 보고 있는 상품
+const categoryId = 9      // 현재 상품의 카테고리
+
+const res = await fetch(
+  `/api/loccishop/v1/products?categoryId=${categoryId}&exclude=${productId}&sort=rating&limit=10`
+)
+const { data } = await res.json()
+// data.products → 같은 카테고리의 추천 상품 (현재 상품 제외, 평점순)
+```
+
+### 방법 2: GET /products/{id}/related (기존 API)
+
+```
+GET /api/loccishop/v1/products/{id}/related?limit=10&sort=rating
+```
+
+```javascript
+// 상품 ID만 있으면 자동으로 같은 카테고리 추천
+const res = await fetch(`/api/loccishop/v1/products/${productId}/related?limit=10&sort=rating`)
+const { data } = await res.json()
+// data.products → 같은 카테고리, 현재 상품 자동 제외
+```
+
+### 두 방법 비교
+
+| 항목 | GET /products + exclude | GET /products/{id}/related |
+|------|:----------------------:|:-------------------------:|
+| categoryId 직접 지정 | O | X (자동) |
+| 현재 상품 제외 | `exclude` 파라미터 | 자동 |
+| sort 옵션 | O | O |
+| 페이지네이션 | O | X (limit만) |
+| badge 필터 | O | X |
+
+> 단순한 추천이면 `related` API가 간편합니다. 세밀한 제어가 필요하면 `GET /products`를 쓰세요.
+
+---
+
+## 파라미터 상세
+
+### GET /products — 추가된 파라미터
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|--------|------|
+| `exclude` | number | X | - | 목록에서 제외할 상품 ID |
+| `sort` | string | X | `latest` | 정렬 기준 |
+
+### sort 옵션 (전체)
+
+| 값 | 설명 |
+|----|------|
+| `latest` | 최신순 (기본값) |
+| `price_asc` | 낮은 가격순 |
+| `price_desc` | 높은 가격순 |
+| `popular` | 판매량순 |
+| `rating` | **평점순** (신규) — 평점 높은 순, 동점이면 리뷰 많은 순 |
+
+### GET /products/{id}/related — 추가된 파라미터
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|---------|------|:----:|--------|------|
+| `sort` | string | X | `latest` | 정렬 기준 (위 표와 동일) |
+| `limit` | number | X | `10` | 반환 개수 |
+
+---
+
+## 호출 예시
+
+```bash
+# 카테고리 9, 상품 1 제외, 평점순, 10건
+curl "https://api.fullstackfamily.com/api/loccishop/v1/products?categoryId=9&exclude=1&sort=rating&limit=10"
+
+# related API로 동일한 결과
+curl "https://api.fullstackfamily.com/api/loccishop/v1/products/1/related?sort=rating&limit=10"
+
+# 가격 낮은순
+curl "https://api.fullstackfamily.com/api/loccishop/v1/products?categoryId=9&sort=price_asc&limit=5"
+
+# 인기순
+curl "https://api.fullstackfamily.com/api/loccishop/v1/products?categoryId=9&sort=popular&limit=5"
+```
+
+프로덕션에 이미 반영되었습니다.


### PR DESCRIPTION
## Summary

상품 상세 페이지에서 같은 카테고리의 추천 상품을 보여주기 위한 API 기능이 추가되었습니다.

### 변경 내용

**GET /products — 파라미터 추가**
- `exclude` (number, 선택): 목록에서 제외할 상품 ID (현재 상품 제외용)
- `sort=rating`: 평점순 정렬 신규 추가 (averageRating DESC, reviewCount DESC)

**GET /products/{id}/related — 파라미터 추가**
- `sort` (string, 선택): 기존 createdAt 고정 → 정렬 선택 가능 (latest, price_asc, price_desc, popular, rating)

### 사용 예시

```
# 추천 상품: 카테고리 9, 상품 5 제외, 평점순 10건
GET /products?categoryId=9&exclude=5&sort=rating&limit=10

# 또는 related API 활용
GET /products/5/related?sort=rating&limit=10
```

### 프로덕션 반영 완료

## Test plan

- [x] exclude로 특정 상품 제외 확인
- [x] sort=rating 평점순 정렬 확인
- [x] related API + sort 파라미터 동작 확인
- [x] 기존 파라미터 (categoryId, badge, latest 등) 호환성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)