### PR TITLE
리뷰 목록 응답에 isMyReview 필드 추가 안내

### DIFF
--- a/docs/api/review_is_my_review_guide.md
+++ b/docs/api/review_is_my_review_guide.md
@@ -1,0 +1,231 @@
+# `isMyReview` 필드 사용 가이드
+
+리뷰 수정/삭제 버튼을 본인 리뷰에만 노출하기 위한 `isMyReview` 필드 사용법입니다.
+
+> **API**: `GET /api/loccishop/v1/products/{id}/reviews`
+> **추가된 필드**: `reviews[].isMyReview` (boolean)
+
+---
+
+## 필드 동작 규칙
+
+| 상황                                     | `isMyReview` |
+| ---------------------------------------- | ------------ |
+| 비로그인 사용자가 호출                    | `false`      |
+| 로그인 사용자가 본인이 작성한 리뷰를 조회 | `true`       |
+| 로그인 사용자가 다른 사람의 리뷰를 조회   | `false`      |
+
+- 인증 토큰(`Authorization: Bearer {token}`)을 함께 보내야 `isMyReview`가 올바르게 계산됩니다.
+- 토큰 없이 호출하면 모든 리뷰의 `isMyReview`는 `false`로 내려옵니다.
+
+---
+
+## 응답 예시
+
+### 로그인 사용자가 본인 + 타인 리뷰 목록을 조회
+
+```json
+{
+  "success": true,
+  "data": {
+    "reviews": [
+      {
+        "id": 15,
+        "isMyReview": true,
+        "title": "내가 쓴 리뷰",
+        "content": "...",
+        "author": "테스터",
+        "rating": 5,
+        "reviewImages": [],
+        "recommendCount": 0,
+        "isRecommended": false
+      },
+      {
+        "id": 14,
+        "isMyReview": false,
+        "title": "다른 사람이 쓴 리뷰",
+        "content": "...",
+        "author": "Jay",
+        "rating": 4,
+        "reviewImages": [],
+        "recommendCount": 3,
+        "isRecommended": true
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 프런트엔드 사용 예시
+
+### 1. 리뷰 카드 렌더링
+
+```js
+function renderReviewCard(review) {
+  const actions = review.isMyReview
+    ? `
+      <div class="review-actions">
+        <button class="btn-edit" data-review-id="${review.id}">수정</button>
+        <button class="btn-delete" data-review-id="${review.id}">삭제</button>
+      </div>
+    `
+    : '';
+
+  return `
+    <article class="review-card">
+      <header>
+        <h3>${review.title}</h3>
+        <span class="rating">⭐ ${review.rating}</span>
+      </header>
+      <p class="author">${review.author}</p>
+      <p class="content">${review.content}</p>
+      ${actions}
+    </article>
+  `;
+}
+```
+
+### 2. 리뷰 목록 조회 (토큰 포함)
+
+```js
+async function fetchReviews(productId, page = 1) {
+  const token = localStorage.getItem('accessToken');
+  const headers = {};
+
+  // 로그인한 경우에만 토큰 전송 — isMyReview가 정확하게 계산됨
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(
+    `/api/loccishop/v1/products/${productId}/reviews?page=${page}&limit=10`,
+    { headers }
+  );
+
+  const result = await res.json();
+  return result.data.reviews;
+}
+```
+
+### 3. 수정/삭제 버튼 이벤트 연결
+
+```js
+async function renderReviewList(productId) {
+  const reviews = await fetchReviews(productId);
+  const container = document.querySelector('.review-list');
+
+  container.innerHTML = reviews.map(renderReviewCard).join('');
+
+  // 본인 리뷰에만 버튼이 있으므로 이벤트가 본인 리뷰에만 붙음
+  container.querySelectorAll('.btn-edit').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      const reviewId = e.target.dataset.reviewId;
+      openEditModal(reviewId);
+    });
+  });
+
+  container.querySelectorAll('.btn-delete').forEach(btn => {
+    btn.addEventListener('click', async (e) => {
+      const reviewId = e.target.dataset.reviewId;
+      if (confirm('리뷰를 삭제하시겠습니까?')) {
+        await deleteReview(reviewId);
+        await renderReviewList(productId); // 재조회
+      }
+    });
+  });
+}
+```
+
+### 4. 리뷰 삭제 호출
+
+```js
+async function deleteReview(reviewId) {
+  const token = localStorage.getItem('accessToken');
+  const res = await fetch(`/api/loccishop/v1/members/me/reviews/${reviewId}`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  return res.json();
+}
+```
+
+---
+
+## 테스트 절차 (curl)
+
+### 1. 비로그인 상태 테스트
+
+```bash
+curl -s "https://api.fullstackfamily.com/api/loccishop/v1/products/5/reviews?limit=5" \
+  | python3 -m json.tool
+```
+
+**기대 결과**: 모든 리뷰의 `isMyReview`가 `false`
+
+### 2. 본인 리뷰 조회 테스트
+
+```bash
+# 1) 로그인
+TOKEN=$(curl -s -X POST https://api.fullstackfamily.com/api/loccishop/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"testuser","password":"Test1234!"}' \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['accessToken'])")
+
+# 2) testuser가 작성한 리뷰가 있는 상품 조회
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.fullstackfamily.com/api/loccishop/v1/products/5/reviews" \
+  | python3 -m json.tool
+```
+
+**기대 결과**: testuser가 작성한 리뷰만 `isMyReview: true`, 나머지는 `false`
+
+### 3. 다른 사용자 리뷰 조회 테스트
+
+```bash
+# 신규 유저 가입
+SUFFIX=$(date +%s)
+curl -s -X POST https://api.fullstackfamily.com/api/loccishop/v1/auth/signup \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"username\":\"revtest$SUFFIX\",
+    \"password\":\"Test1234!\",
+    \"name\":\"리뷰테스터\",
+    \"email\":\"revtest$SUFFIX@example.com\"
+  }"
+
+# 신규 유저로 로그인
+OTHER_TOKEN=$(curl -s -X POST https://api.fullstackfamily.com/api/loccishop/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"revtest$SUFFIX\",\"password\":\"Test1234!\"}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['accessToken'])")
+
+# testuser가 쓴 리뷰 조회 — isMyReview는 false여야 함
+curl -s -H "Authorization: Bearer $OTHER_TOKEN" \
+  "https://api.fullstackfamily.com/api/loccishop/v1/products/5/reviews" \
+  | python3 -m json.tool
+```
+
+**기대 결과**: 모든 리뷰의 `isMyReview`가 `false`
+
+---
+
+## 실서버 테스트 결과
+
+| 시나리오 | 기대값 | 실제값 |
+| -------- | ------ | ------ |
+| 비로그인 호출 | `false` | `false` |
+| testuser가 본인 리뷰 조회 | `true` | `true` |
+| 다른 유저(revtest)가 testuser 리뷰 조회 | `false` | `false` |
+
+---
+
+## 주의사항
+
+- **비로그인 상태에서는 수정/삭제 버튼을 노출하지 말 것**
+  `isMyReview`가 `false`이므로 자연스럽게 숨겨지지만, 프런트엔드에서 토큰 전달을 빠뜨리면 본인 리뷰도 `false`로 내려옵니다.
+- **삭제/수정 API는 서버에서 다시 본인 확인**
+  `isMyReview`는 UI 노출용이고, 실제 수정/삭제 API(`PATCH/DELETE /members/me/reviews/:id`)에서도 본인 확인을 다시 합니다. 악의적인 클라이언트가 `isMyReview`를 위조해도 타인의 리뷰는 수정/삭제되지 않습니다.
+- **권장 패턴: 옵셔널 토큰**
+  조회 API 호출 시 토큰이 있으면 넣고, 없으면 생략하는 옵셔널 방식으로 구현하세요. 비로그인 사용자에게도 리뷰 목록은 보여야 하지만, 로그인한 사용자에게는 `isMyReview`가 정확히 계산되어야 합니다.

--- a/docs/api/reviews.md
+++ b/docs/api/reviews.md
@@ -109,16 +109,20 @@ console.log(result.data.imageUrl);
 
 ### Response
 
-| key                      | 설명                 | 비고                       |
-| ------------------------ | -------------------- | -------------------------- |
-| reviews[].id             | 리뷰 고유 번호       |                            |
-| reviews[].title          | 리뷰 제목            |                            |
-| reviews[].content        | 리뷰 본문            |                            |
-| reviews[].rating         | 별점                 |                            |
-| reviews[].author         | 작성자 이름          |                            |
-| reviews[].createdAt      | 작성일               |                            |
-| reviews[].reviewImages[] | 리뷰 이미지 URL 배열 | 텍스트 리뷰면 빈 배열 `[]` |
-| reviews[].recommendCount | 추천 수              |                            |
+| key                      | 설명                 | 비고                                                                |
+| ------------------------ | -------------------- | ------------------------------------------------------------------- |
+| reviews[].id             | 리뷰 고유 번호       |                                                                     |
+| reviews[].isMyReview     | 본인 리뷰 여부       | 로그인한 사용자가 작성한 리뷰면 `true`, 그 외(비로그인/타인)는 `false` |
+| reviews[].title          | 리뷰 제목            |                                                                     |
+| reviews[].content        | 리뷰 본문            |                                                                     |
+| reviews[].rating         | 별점                 |                                                                     |
+| reviews[].author         | 작성자 이름          |                                                                     |
+| reviews[].createdAt      | 작성일               |                                                                     |
+| reviews[].reviewImages[] | 리뷰 이미지 URL 배열 | 텍스트 리뷰면 빈 배열 `[]`                                          |
+| reviews[].recommendCount | 추천 수              |                                                                     |
+| reviews[].isRecommended  | 추천 여부 (본인 기준) | 로그인 사용자가 이 리뷰에 추천했으면 `true`                         |
+
+> `isMyReview` 필드는 본인 리뷰에만 수정/삭제 버튼을 노출하는 데 사용합니다. 비로그인 상태에서는 항상 `false`입니다.
 
 ### Example
 
@@ -127,13 +131,15 @@ console.log(result.data.imageUrl);
   "reviews": [
     {
       "id": 101,
+      "isMyReview": true,
       "title": "핸드크림계 국밥",
       "content": "코코넛 향에 하드한 핸드크림. 보습력이 매우 우수함...",
       "rating": 5,
       "author": "Jay",
       "createdAt": "2025-06-01",
       "reviewImages": ["https://cdn.../thumb.jpg"],
-      "recommendCount": 12
+      "recommendCount": 12,
+      "isRecommended": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

SBS팀 팀장 추유나 수강생의 요청사항 반영. 본인 작성 리뷰 수정/삭제 기능 구현을 위해 `GET /api/loccishop/v1/products/{id}/reviews` 응답에 `isMyReview` 필드가 추가되었습니다.

## 변경 파일

- `docs/api/reviews.md` — 상품 리뷰 조회 섹션의 Response 테이블 및 Example JSON에 `isMyReview`, `isRecommended` 필드 추가
- `docs/api/review_is_my_review_guide.md` — 신규 작성
  - 필드 동작 규칙 (로그인/비로그인/본인/타인)
  - 프런트엔드 렌더링 + 이벤트 연결 코드 예시
  - curl 테스트 절차 (3가지 시나리오)
  - 보안 주의사항 (서버 재검증, 옵셔널 토큰 전달)

## 필드 동작

| 상황 | `isMyReview` |
|------|--------------|
| 비로그인 사용자 | `false` |
| 로그인 사용자 본인 리뷰 | `true` |
| 로그인 사용자 타인 리뷰 | `false` |

## 실서버 테스트 결과

| 시나리오 | 기대 | 실제 |
|---------|------|------|
| 비로그인 호출 (product 5) | `false` | `false` ✓ |
| testuser 로그인 후 본인 리뷰 조회 | `true` | `true` ✓ |
| 신규 유저(revtest)로 testuser 리뷰 조회 | `false` | `false` ✓ |

## 사용 예시

```js
// 본인 리뷰에만 수정/삭제 버튼 노출
const actions = review.isMyReview
  ? `<button class="btn-edit">수정</button>
     <button class="btn-delete">삭제</button>`
  : '';
```

## 주의사항

`isMyReview`는 UI 노출용이며, 실제 수정/삭제 API는 서버에서 본인 여부를 다시 검증합니다. 조회 API 호출 시 **로그인 상태라면 반드시 Authorization 헤더를 같이 전달**해야 `isMyReview`가 정확히 계산됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)