### PR TITLE
fix: renderCart에서 updateOrderSummary 공통 함수로 교체 (#218)

### DIFF
--- a/src/pages/cart/handlers/renderCart.js
+++ b/src/pages/cart/handlers/renderCart.js
@@ -1,16 +1,5 @@
 import { editCartItem, deleteCartItem } from "/src/js/api/cart/index.js";
-
-//주요 요약
-function updateSummary({ subtotal, total, shipping }) {
-  const productPrice = document.getElementById("summary-product-price");
-  const shippingFee = document.getElementById("summary-shipping");
-  const totalPrice = document.getElementById("summary-total");
-
-  productPrice.textContent = `₩${subtotal.toLocaleString()}`;
-  shippingFee.textContent =
-    shipping === 0 ? "무료" : `₩${shipping.toLocaleString()}`;
-  totalPrice.textContent = `₩${total.toLocaleString()}`;
-}
+import { updateOrderSummary } from "/src/components/ui/orderSummary.js";
 
 //장바구니 렌더링
 export function renderCart({ items, total, shipping }) {
@@ -36,12 +25,12 @@ export function renderCart({ items, total, shipping }) {
     cartList.append(empty);
 
     cartCount.textContent = 0;
-    updateSummary({ subtotal: 0, total: 0, shipping: 0 });
+    updateOrderSummary({ subtotal: 0, total: 0, shipping: 0 });
     return;
   }
 
   cartCount.textContent = items.length;
-  updateSummary({ subtotal: total - shipping, total, shipping });
+  updateOrderSummary({ subtotal: total - shipping, total, shipping });
   items.forEach((item) => {
     cartList.append(createCartItem(item));
   });
@@ -134,7 +123,7 @@ function createCartItem(item) {
     currentQty--;
     qtyDisplay.textContent = currentQty;
     totalEl.textContent = `₩${((discountPrice ?? price) * currentQty).toLocaleString()}`;
-    updateSummary({
+    updateOrderSummary({
       subtotal: result.summary.subtotal,
       total: result.summary.total,
       shipping: result.summary.shipping,
@@ -155,7 +144,7 @@ function createCartItem(item) {
     currentQty++;
     qtyDisplay.textContent = currentQty;
     totalEl.textContent = `₩${((discountPrice ?? price) * currentQty).toLocaleString()}`;
-    updateSummary({
+    updateOrderSummary({
       subtotal: result.summary.subtotal,
       total: result.summary.total,
       shipping: result.summary.shipping,
@@ -203,9 +192,9 @@ function createCartItem(item) {
         empty.append(msg, link);
         cartList.append(empty);
 
-        updateSummary({ subtotal: 0, total: 0, shipping: 0 });
+        updateOrderSummary({ subtotal: 0, total: 0, shipping: 0 });
       } else {
-        updateSummary({
+        updateOrderSummary({
           subtotal: result.summary.subtotal,
           total: result.summary.total,
           shipping: result.summary.shipping,


### PR DESCRIPTION
## 📌 작업 내용

- renderCart.js의 updateSummary 제거
- orderSummary.js의 updateOrderSummary import 후 사용

---

## PR 유형

- [ ] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] style: 코드 스타일 변경 (UI 포함)
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정
- [ ] chore: 빌드, 설정, 패키지, 파일 구조 변경

---

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #218