### PR TITLE
fix: 배송지 선택 UX 개선 및 결제 페이지 연동 수정 #245

### DIFF
--- a/src/pages/order/shipping/handlers/renderAddress.js
+++ b/src/pages/order/shipping/handlers/renderAddress.js
@@ -105,6 +105,10 @@ function createAddressItem(address, isSelected = false) {
   zipEl.className = "text-sm text-zambezi";
 
   infoWrapper.append(nameRow, phoneEl, addressEl, zipEl);
+  infoWrapper.addEventListener("click", () => {
+    radio.checked = true;
+    selectedAddressId = addressId;
+  });
 
   //수정,삭제 버튼
   const buttonWrapper = document.createElement("div");

--- a/src/pages/order/shipping/index.js
+++ b/src/pages/order/shipping/index.js
@@ -17,15 +17,23 @@ async function initShippingPage() {
     showCoupon: false,
     showCartToggle: true,
     btnText: "결제하기",
-    onBtnClick: () => {
+    onBtnClick: async () => {
       const addressId = getSelectedAddressId();
 
       if (!addressId) {
         alert("배송지를 선택해주세요.");
         return;
       }
+
+      const addresses = await fetchAddresses();
+      const selectedAddress = addresses.find((a) => a.addressId === addressId);
+
       const memo = getDeliveryMemo();
-      sessionStorage.setItem("selectedAddressId", addressId);
+
+      sessionStorage.setItem(
+        "selectedAddress",
+        JSON.stringify(selectedAddress),
+      );
       sessionStorage.setItem("deliveryMemo", memo);
       location.href = "/src/pages/order/payment/index.html";
     },


### PR DESCRIPTION
## 📌 작업 내용

- 배송지 아이템의 텍스트 영역 클릭 시 라디오 버튼이 선택되지 않던 버그 수정
- 기존 `selectedAddressId`만 저장하던 방식에서 `selectedAddress` 전체 객체를 저장하는 방식으로 변경하여 결제 페이지에서 API 재호출 없이 배송지 정보 사용 가능

---

## PR 유형

- [ ] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] style: 코드 스타일 변경 (UI 포함)
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정
- [ ] chore: 빌드, 설정, 패키지, 파일 구조 변경

---

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #245
