### PR TITLE
fix: 배너 데이터가 없을 때 캐러셀이 깨지는 문제 수정

### DIFF
--- a/src/pages/main/index.js
+++ b/src/pages/main/index.js
@@ -169,22 +169,53 @@ function initRotatingCarousel(initialSlides, slideSets) {
   let currentVIdx = 1;
 
   function buildTrack(newSlides) {
-    slides = newSlides;
+    slides = Array.isArray(newSlides) ? newSlides : [];
     track.innerHTML = "";
+
+    if (slides.length === 0) {
+      track.innerHTML = `
+        <div class="w-full py-16 text-center text-empress">
+          등록된 배너가 없습니다.
+        </div>
+      `;
+      counter.textContent = "0 / 0";
+      prevLabel.textContent = "";
+      nextLabel.textContent = "";
+      prevBtn.disabled = true;
+      nextBtn.disabled = true;
+      return false;
+    }
+
+    if (slides.length === 1) {
+      track.append(createCarouselSlide(slides[0]));
+      counter.textContent = "1 / 1";
+      prevLabel.textContent = "";
+      nextLabel.textContent = "";
+      prevBtn.disabled = true;
+      nextBtn.disabled = true;
+      return false;
+    }
+
+    prevBtn.disabled = false;
+    nextBtn.disabled = false;
+
     track.append(createCarouselSlide(slides[slides.length - 1])); // 마지막 클론
     slides.forEach((s) => track.append(createCarouselSlide(s)));
     track.append(createCarouselSlide(slides[0])); // 첫번째 클론
+    return true;
   }
 
   function renderSlides(newSlides) {
-    buildTrack(newSlides);
+    const built = buildTrack(newSlides);
+    if (!built) return;
+
     currentVIdx = 1;
     applyTranslate(getTranslateForIdx(currentVIdx), false);
     updateSlideStyles();
     updateNav();
   }
 
-  buildTrack(slides);
+  const built = buildTrack(slides);
 
   let isDragging = false;
   let dragStartX = 0;
@@ -275,9 +306,11 @@ function initRotatingCarousel(initialSlides, slideSets) {
     );
   }
 
-  applyTranslate(getTranslateForIdx(currentVIdx), false);
-  updateSlideStyles();
-  updateNav();
+  if (built) {
+    applyTranslate(getTranslateForIdx(currentVIdx), false);
+    updateSlideStyles();
+    updateNav();
+  }
 
   prevBtn.addEventListener("click", () => goTo(currentVIdx - 1));
   nextBtn.addEventListener("click", () => goTo(currentVIdx + 1));


### PR DESCRIPTION
## 📌 작업 내용

- newSlides가 배열이 아닐 경우 []로 초기화
- 슬라이드 0개시 '등록된 배너가 없습니다' 문구표시 후 이전/다음버튼 비활성화
- 슬라이드 1개시 단일 이미지 표시 후 이전/다음버튼 비활성화
- 슬라이드 2개 이상 시 기존 무한 캐러셀 로직 유지
---

## PR 유형

- [ ] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] style: 코드 스타일 변경 (UI 포함)
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정
- [ ] chore: 빌드, 설정, 패키지, 파일 구조 변경

---

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
resolves #347 
