### PR TITLE
refactor: carouselSlide innerHTML을 createElement로 교체

### DIFF
--- a/src/components/ui/carouselSlide.js
+++ b/src/components/ui/carouselSlide.js
@@ -3,15 +3,19 @@ export function createCarouselSlide({ imageUrl, name }) {
   el.className =
     "rotating-slide flex-shrink-0 select-none w-[min(450px,90vw)] md:w-[450px] lg:w-[914px] xl:w-[942px]";
   el.style.transition = "transform 0.45s ease, opacity 0.45s ease";
-  el.innerHTML = `
-    <figure class="w-full aspect-[450/638] md:h-[638px] md:[aspect-ratio:auto] lg:h-[457px] xl:h-[471px] overflow-hidden shadow-sm bg-[#f4f1ea]">
-      <img
-        src="${imageUrl}"
-        alt="${name}"
-        class="w-full h-full object-contain md:object-cover pointer-events-none"
-        draggable="false"
-      />
-    </figure>
-  `;
+
+  const figure = document.createElement("figure");
+  figure.className =
+    "w-full aspect-[450/638] md:h-[638px] md:[aspect-ratio:auto] lg:h-[457px] xl:h-[471px] overflow-hidden shadow-sm bg-[#f4f1ea]";
+
+  const img = document.createElement("img");
+  img.src = imageUrl ?? "";
+  img.alt = name ?? "";
+  img.className =
+    "w-full h-full object-contain md:object-cover pointer-events-none";
+  img.draggable = false;
+
+  figure.append(img);
+  el.append(figure);
   return el;
 }


### PR DESCRIPTION
## 📌 작업 내용

- innerHtml 제거
- figure,img요소를 createElemen()로 직접 생성
- img.src,img.alt를 속성으로 직접 할당하여 외부데이터가 html로 해석되지 않음
- 
---

## PR 유형

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [x] refactor: 코드 리팩토링
- [ ] style: 코드 스타일 변경 (UI 포함)
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정
- [ ] chore: 빌드, 설정, 패키지, 파일 구조 변경

---

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
resolves #348 
