### PR TITLE
feat: 마이페이지 주문 내역 및 주문 상세 기능 구현

### DIFF
--- a/src/components/ui/orderDetail.js
+++ b/src/components/ui/orderDetail.js
@@ -71,6 +71,7 @@ export function createOrderItems(items) {
 
 export function createShippingInfo(shippingAddress) {
   const section = document.createElement("div");
+  section.id = "shipping-info-section";
   section.className = "flex flex-col gap-3 py-6 border-b border-gray-200";
 
   const h2 = document.createElement("h2");
@@ -85,9 +86,6 @@ export function createShippingInfo(shippingAddress) {
     { label: "연락처", value: shippingAddress.receiverPhone },
     { label: "주소", value: shippingAddress.baseAddress },
     { label: "상세주소", value: shippingAddress.detailAddress },
-    ...(shippingAddress.shippingRequest
-      ? [{ label: "배송 요청사항", value: shippingAddress.shippingRequest }]
-      : []),
   ];
 
   rows.forEach(({ label, value }) => {

--- a/src/js/api/client.js
+++ b/src/js/api/client.js
@@ -66,3 +66,39 @@ export async function fetchAPIWithFormData(path, formData) {
   }
   return json.data;
 }
+
+//meta 반환함수
+export async function fetchAPIWithMeta(path, options = {}) {
+  const token = localStorage.getItem("token");
+
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: options.method ?? "GET",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token && { Authorization: `Bearer ${token}` }),
+      ...options.headers,
+    },
+    ...(options.body && { body: JSON.stringify(options.body) }),
+  });
+
+  if (!res.ok) {
+    if (res.status === 401) {
+      localStorage.removeItem("token");
+      localStorage.removeItem("role");
+      localStorage.removeItem("member");
+      alert("로그인이 필요한 서비스입니다.");
+      openLoginModal();
+      return;
+    }
+    throw new Error(`API 오류: ${res.status}`);
+  }
+
+  const json = await res.json();
+
+  if (!json.success) {
+    throw new Error("서버 오류가 발생했습니다.");
+  }
+
+  return { data: json.data, meta: json.meta };
+}

--- a/src/js/api/order/index.js
+++ b/src/js/api/order/index.js
@@ -1,4 +1,4 @@
-import { fetchAPI } from "/src/js/api/client.js";
+import { fetchAPI, fetchAPIWithMeta } from "/src/js/api/client.js";
 
 // 리뷰 작성 가능 여부 확인
 export async function fetchReviewable({ productId, orderId }) {
@@ -24,8 +24,10 @@ export async function createOrder(orderData) {
 }
 
 //주문 조회
-export async function fetchOrder() {
-  return await fetchAPI("/members/me/orders");
+export async function fetchOrder(page = 1, limit = 10) {
+  return await fetchAPIWithMeta(
+    `/members/me/orders?page=${page}&limit=${limit}`,
+  );
 }
 
 //주문 상세 조회
@@ -34,11 +36,17 @@ export async function fetchOrderDetail(orderId) {
 }
 
 //주문 취소
-export async function cancelOrder(orderId, cancelReson) {
-  const result = await fetchAPI(`/members/me/orders/${orderId}`, {
+export async function cancelOrder(orderId, cancelReason) {
+  return await fetchAPI(`/members/me/orders/${orderId}/cancel`, {
     method: "POST",
-    body: cancelReson,
+    body: cancelReason,
   });
+}
 
-  return result;
+// 배송지 수정
+export async function updateOrderShipping(orderId, data) {
+  return await fetchAPI(`/members/me/orders/${orderId}`, {
+    method: "PATCH",
+    body: data,
+  });
 }

--- a/src/pages/mypage/components/myOrderTemplate.js
+++ b/src/pages/mypage/components/myOrderTemplate.js
@@ -17,7 +17,7 @@ export function getOrderTemplate() {
         <dd class="text-3xl font-light text-dark-woody" id="status-completed">0</dd>
       </div>
       <div class="flex-1 border-l border-cararra/50 pl-10">
-        <dt class="text-[10px] text-empress uppercase tracking-[0.2em] mb-4">Returns</dt>
+        <dt class="text-[10px] text-empress uppercase tracking-[0.2em] mb-4">Canceled</dt>
         <dd class="text-3xl font-light text-dark-woody" id="status-cancelled">0</dd>
       </div>
     </dl>

--- a/src/pages/mypage/handlers/renderOrderList.js
+++ b/src/pages/mypage/handlers/renderOrderList.js
@@ -1,5 +1,6 @@
 import { getOrderTemplate } from "/src/pages/mypage/components/myOrderTemplate.js";
 import { fetchOrder } from "/src/js/api/order/index.js";
+import { createPagination } from "/src/components/ui/pagination.js"; // 경로 확인해줘요
 
 const STATUS_MAP = {
   PAID: { text: "결제 완료", class: "text-dark-woody" },
@@ -8,19 +9,21 @@ const STATUS_MAP = {
   CANCELLED: { text: "주문 취소", class: "text-dark-woody" },
 };
 
-export async function renderOrderList() {
+export async function renderOrderList(page = 1) {
   const container = document.querySelector("#mypage-content");
-  if (!container) {
-    return;
-  }
-  container.innerHTML = getOrderTemplate();
+  if (!container) return;
 
+  container.innerHTML = getOrderTemplate();
   const tbody = document.querySelector("#order-list-container");
 
   try {
-    const res = await fetchOrder();
+    // 현황용 전체 조회 + 페이지용 조회 동시에
+    const [allRes, pageRes] = await Promise.all([
+      fetchOrder(1, 999), // 전체
+      fetchOrder(page), // 현재 페이지
+    ]);
 
-    if (!res || !res.orders || res.orders.length === 0) {
+    if (!pageRes || !pageRes.data?.orders || pageRes.data.orders.length === 0) {
       tbody.innerHTML = `
         <tr>
           <td colspan="4" class="py-10 text-center text-sm text-empress">
@@ -31,9 +34,19 @@ export async function renderOrderList() {
       return;
     }
 
-    const orders = res.orders;
-    updateOrderSummary(orders);
-    renderOrders(orders, tbody);
+    updateOrderSummary(allRes.data.orders); // 전체 기준으로 현황 계산
+    renderOrders(pageRes.data.orders, tbody);
+
+    const { totalPages, page: currentPage } = pageRes.meta.pagination;
+    const pagination = createPagination({
+      totalPages,
+      currentPage,
+      onPageChange: (newPage) => renderOrderList(newPage),
+    });
+    pagination.className += " justify-center mt-6";
+
+    const tableWrapper = tbody.closest(".overflow-x-auto");
+    tableWrapper.after(pagination);
   } catch (error) {
     console.error("Order Load Error:", error);
     tbody.innerHTML = `
@@ -56,9 +69,7 @@ function updateOrderSummary(orders) {
 
   const set = (id, count) => {
     const el = document.getElementById(id);
-    if (el) {
-      el.textContent = count;
-    }
+    if (el) el.textContent = count;
   };
 
   set("status-ordered", counts.PAID);
@@ -84,23 +95,23 @@ function renderOrders(orders, tbody) {
       "grid grid-cols-[1fr_3fr_0.5fr_0.5fr] px-4 py-6 items-center text-sm transition-colors hover:bg-cararra/10 cursor-pointer";
 
     tr.addEventListener("click", () => {
-      window.location.href = `/src/pages/mypage/order-detail/?id=${order.orderId}`;
+      window.location.href = `/src/pages/mypage/order-detail/?id=${order.orderId}&from=order`;
     });
 
     tr.innerHTML = `
-  <td class="flex flex-col gap-1">
-    <span class="order-date text-dark-woody font-medium"></span>
-    <span class="order-no text-[10px] text-empress"></span>
-  </td>
-  <td class="flex items-center gap-4">
-    <img src="" alt="" class="order-thumb w-16 h-20 object-cover bg-cararra">
-    <span class="product-name font-bold text-dark-woody truncate max-w-[350px]"></span>
-  </td>
-  <td class="price-text text-center font-light text-dark-woody"></td>
-  <td class="text-right">
-    <span class="status-text text-[11px] font-bold tracking-tighter"></span>
-  </td>
-`;
+      <td class="flex flex-col gap-1">
+        <span class="order-date text-dark-woody font-medium"></span>
+        <span class="order-no text-[10px] text-empress"></span>
+      </td>
+      <td class="flex items-center gap-4">
+        <img src="" alt="" class="order-thumb w-16 h-20 object-cover bg-cararra">
+        <span class="product-name font-bold text-dark-woody truncate max-w-[350px]"></span>
+      </td>
+      <td class="price-text text-center font-light text-dark-woody"></td>
+      <td class="text-right">
+        <span class="status-text text-[11px] font-bold tracking-tighter"></span>
+      </td>
+    `;
 
     tr.querySelector(".order-date").textContent = date;
     tr.querySelector(".order-no").textContent = order.orderNumber || "";

--- a/src/pages/mypage/index.js
+++ b/src/pages/mypage/index.js
@@ -7,8 +7,12 @@ import {
 async function init() {
   try {
     initMypageEvents();
-    updateSidebarUI("info");
-    await renderSection("info");
+
+    const params = new URLSearchParams(window.location.search);
+    const menu = params.get("menu") || "info";
+
+    updateSidebarUI(menu);
+    await renderSection(menu);
   } catch (error) {
     console.error("마이페이지 로딩 중 오류 발생:", error);
   }

--- a/src/pages/mypage/order-detail/index.html
+++ b/src/pages/mypage/order-detail/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>주문 상세 | L'OcciShop</title>
+    <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <script type="module" src="/src/js/main.js"></script>
     <script
       type="module"
@@ -15,13 +16,15 @@
     <main class="min-w-[400px] px-4 py-10" id="order-detail-main">
       <div class="max-w-[700px] mx-auto px-4 flex flex-col gap-8">
         <div class="flex flex-col gap-3 py-8 border-b border-gray-200">
-          <a
-            href="/src/pages/mypage/index.html"
-            class="text-xs text-empress hover:text-dark-woody transition-colors"
+          <button
+            type="button"
+            id="back-btn"
+            class="text-left cursor-pointer text-xs text-empress hover:text-dark-woody transition-colors"
           >
             ← 주문 내역으로
-          </a>
+          </button>
           <h1 class="text-xl font-bold">주문 상세</h1>
+          <div id="order-status-badge"></div>
           <p id="order-number" class="text-sm text-zambezi"></p>
         </div>
         <div id="order-detail-section"></div>

--- a/src/pages/mypage/order-detail/index.js
+++ b/src/pages/mypage/order-detail/index.js
@@ -1,9 +1,261 @@
-import { fetchOrderDetail } from "/src/js/api/order/index.js";
+import {
+  fetchOrderDetail,
+  cancelOrder,
+  updateOrderShipping,
+} from "/src/js/api/order/index.js";
 import { renderOrderDetail } from "/src/components/ui/orderDetail.js";
+import { createModal } from "/src/components/ui/modal.js";
+
+function createCancelModalContent(onConfirm) {
+  const CANCEL_REASONS = [
+    "단순 변심",
+    "배송 지연",
+    "상품 정보 상이",
+    "다른 상품 주문 예정",
+    "기타",
+  ];
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "flex flex-col gap-4";
+
+  const select = document.createElement("select");
+  select.className = "w-full border border-gray-300 rounded px-3 py-2 text-sm";
+
+  const defaultOption = document.createElement("option");
+  defaultOption.value = "";
+  defaultOption.textContent = "취소 사유를 선택해주세요";
+  defaultOption.disabled = true;
+  defaultOption.selected = true;
+  select.append(defaultOption);
+
+  CANCEL_REASONS.forEach((reason) => {
+    const option = document.createElement("option");
+    option.value = reason;
+    option.textContent = reason;
+    select.append(option);
+  });
+
+  const textarea = document.createElement("textarea");
+  textarea.className =
+    "w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none hidden";
+  textarea.placeholder = "취소 사유를 직접 입력해주세요.";
+  textarea.rows = 3;
+
+  select.addEventListener("change", () => {
+    if (select.value === "기타") {
+      textarea.classList.remove("hidden");
+      textarea.focus();
+    } else {
+      textarea.classList.add("hidden");
+      textarea.value = "";
+    }
+  });
+
+  const confirmBtn = document.createElement("button");
+  confirmBtn.type = "button";
+  confirmBtn.className =
+    "w-full py-3 bg-dark-woody text-white text-sm font-bold hover:opacity-90 transition-opacity";
+  confirmBtn.textContent = "주문 취소";
+  confirmBtn.addEventListener("click", () => {
+    if (!select.value) {
+      alert("취소 사유를 선택해주세요.");
+      return;
+    }
+    if (select.value === "기타" && !textarea.value.trim()) {
+      alert("취소 사유를 입력해주세요.");
+      return;
+    }
+    const reason =
+      select.value === "기타" ? textarea.value.trim() : select.value;
+    onConfirm(reason);
+  });
+
+  wrapper.append(select, textarea, confirmBtn);
+  return wrapper;
+}
+
+function renderShippingForm(shippingAddress, section, onSave) {
+  section.innerHTML = "";
+
+  const h2 = document.createElement("h2");
+  h2.className = "text-sm font-bold";
+  h2.textContent = "배송 정보";
+
+  const form = document.createElement("div");
+  form.className = "flex flex-col gap-3";
+
+  const inputs = {};
+
+  // 1. 수령인, 연락처
+  const topFields = [
+    {
+      label: "수령인",
+      key: "receiverName",
+      type: "text",
+      value: shippingAddress.receiverName,
+    },
+    {
+      label: "연락처",
+      key: "phone",
+      type: "tel",
+      value: shippingAddress.receiverPhone,
+    },
+  ];
+
+  topFields.forEach(({ label, key, type, value }) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "flex gap-4 items-center py-2 border-b border-gray-100";
+
+    const labelEl = document.createElement("label");
+    labelEl.className = "w-24 flex-shrink-0 text-xs text-gray-400";
+    labelEl.textContent = label;
+
+    const input = document.createElement("input");
+    input.type = type;
+    input.value = value ?? "";
+    input.className =
+      "flex-1 border border-gray-300 px-3 py-1.5 text-sm outline-none focus:border-dark-woody";
+
+    if (type === "tel") {
+      input.addEventListener("input", () => {
+        let digits = input.value.replace(/[^0-9]/g, "");
+        if (digits.length <= 3) {
+          input.value = digits;
+        } else if (digits.length <= 7) {
+          input.value = `${digits.slice(0, 3)}-${digits.slice(3)}`;
+        } else {
+          input.value = `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7, 11)}`;
+        }
+      });
+    }
+
+    inputs[key] = input;
+    wrapper.append(labelEl, input);
+    form.append(wrapper);
+  });
+
+  // 2. 기본 주소 (다음 검색)
+  const addressWrapper = document.createElement("div");
+  addressWrapper.className =
+    "flex gap-4 items-center py-2 border-b border-gray-100";
+
+  const addressLabel = document.createElement("span");
+  addressLabel.className = "w-24 flex-shrink-0 text-xs text-gray-400";
+  addressLabel.textContent = "기본 주소";
+
+  const addressRow = document.createElement("div");
+  addressRow.className = "flex-1 flex gap-2";
+
+  const addressInput = document.createElement("input");
+  addressInput.type = "text";
+  addressInput.value = shippingAddress.baseAddress ?? "";
+  addressInput.readOnly = true;
+  addressInput.className =
+    "flex-1 border border-gray-300 px-3 py-1.5 text-sm outline-none bg-gray-50";
+
+  const searchBtn = document.createElement("button");
+  searchBtn.type = "button";
+  searchBtn.className =
+    "px-3 py-1.5 border border-gray-300 text-sm hover:bg-cararra transition-colors flex-shrink-0";
+  searchBtn.textContent = "주소 검색";
+  searchBtn.addEventListener("click", () => {
+    new daum.Postcode({
+      oncomplete: (data) => {
+        addressInput.value = data.roadAddress;
+      },
+    }).open();
+  });
+
+  addressRow.append(addressInput, searchBtn);
+  addressWrapper.append(addressLabel, addressRow);
+  inputs.baseAddress = addressInput;
+  form.append(addressWrapper);
+
+  // 3. 상세주소, 배송 요청사항
+  const bottomFields = [
+    {
+      label: "상세주소",
+      key: "detailAddress",
+      type: "text",
+      value: shippingAddress.detailAddress,
+    },
+  ];
+
+  bottomFields.forEach(({ label, key, type, value }) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "flex gap-4 items-center py-2 border-b border-gray-100";
+
+    const labelEl = document.createElement("label");
+    labelEl.className = "w-24 flex-shrink-0 text-xs text-gray-400";
+    labelEl.textContent = label;
+
+    const input = document.createElement("input");
+    input.type = type;
+    input.value = value ?? "";
+    input.className =
+      "flex-1 border border-gray-300 px-3 py-1.5 text-sm outline-none focus:border-dark-woody";
+
+    inputs[key] = input;
+    wrapper.append(labelEl, input);
+    form.append(wrapper);
+  });
+
+  // 4. 버튼 그룹
+  const btnGroup = document.createElement("div");
+  btnGroup.className = "flex gap-2 mt-2";
+
+  const saveBtn = document.createElement("button");
+  saveBtn.type = "button";
+  saveBtn.className =
+    "flex-1 py-2 bg-dark-woody text-white text-sm font-bold hover:opacity-90 transition-opacity";
+  saveBtn.textContent = "저장";
+  saveBtn.addEventListener("click", () => {
+    const formData = {
+      receiverName: inputs.receiverName.value.trim(),
+      receiverPhone: inputs.phone.value.trim(),
+      baseAddress: inputs.baseAddress.value.trim(),
+      detailAddress: inputs.detailAddress.value.trim(),
+    };
+    console.log(formData);
+    if (
+      !formData.receiverName ||
+      !formData.receiverPhone ||
+      !formData.baseAddress
+    ) {
+      alert("수령인, 연락처, 주소는 필수 항목입니다.");
+      return;
+    }
+
+    onSave(formData);
+  });
+
+  const cancelBtn = document.createElement("button");
+  cancelBtn.type = "button";
+  cancelBtn.className =
+    "flex-1 py-2 border border-gray-300 text-sm font-bold hover:bg-cararra transition-colors";
+  cancelBtn.textContent = "취소";
+  cancelBtn.addEventListener("click", () => {
+    window.location.reload();
+  });
+
+  btnGroup.append(cancelBtn, saveBtn);
+  section.append(h2, form, btnGroup);
+}
 
 async function initOrderDetailPage() {
   const params = new URLSearchParams(window.location.search);
   const orderId = params.get("id");
+
+  document.getElementById("back-btn").addEventListener("click", () => {
+    const params = new URLSearchParams(window.location.search);
+    const from = params.get("from");
+
+    if (from === "order") {
+      window.location.href = "/src/pages/mypage/index.html?menu=order";
+    } else {
+      history.back();
+    }
+  });
 
   if (!orderId) {
     window.location.href = "/";
@@ -12,11 +264,88 @@ async function initOrderDetailPage() {
 
   try {
     const order = await fetchOrderDetail(orderId);
+    console.log(order.shippingAddress);
     const orderNumber = document.getElementById("order-number");
-    const container = document.getElementById("order-detail-section");
-
     orderNumber.textContent = order.orderNumber;
+
+    const STATUS_MAP = {
+      PAID: { text: "결제 완료", class: "text-dark-woody bg-cararra" },
+      SHIPPING: { text: "배송 중", class: "text-ferra bg-merino" },
+      DELIVERED: { text: "배송 완료", class: "text-dark-woody bg-cararra" },
+      CANCELLED: { text: "주문 취소", class: "text-white bg-empress" },
+    };
+
+    const statusInfo = STATUS_MAP[order.status] || {
+      text: order.status,
+      class: "text-dark-woody bg-cararra",
+    };
+
+    const statusBadge = document.createElement("span");
+    statusBadge.className = `text-xs font-bold px-4 py-2 ${statusInfo.class}`;
+    statusBadge.textContent = statusInfo.text;
+
+    document.getElementById("order-status-badge").append(statusBadge);
+
+    const container = document.getElementById("order-detail-section");
     renderOrderDetail(order, container);
+
+    if (order.status === "PAID") {
+      const btnGroup = document.createElement("div");
+      btnGroup.className = "flex gap-3";
+
+      const cancelBtn = document.createElement("button");
+      cancelBtn.type = "button";
+      cancelBtn.className =
+        "flex-1 py-3 border border-gray-300 text-sm font-bold hover:bg-cararra transition-colors";
+      cancelBtn.textContent = "주문 취소";
+      cancelBtn.addEventListener("click", () => {
+        const modalContent = createCancelModalContent(async (reason) => {
+          try {
+            await cancelOrder(orderId, { cancelReason: reason });
+            modal.close();
+            alert("주문이 취소되었습니다.");
+            window.location.reload();
+          } catch (error) {
+            console.error("주문 취소 오류:", error);
+            alert("주문 취소 중 오류가 발생했습니다.");
+          }
+        });
+
+        const modal = createModal({
+          title: "주문 취소",
+          content: modalContent,
+        });
+        modal.open();
+      });
+
+      const editBtn = document.createElement("button");
+      editBtn.type = "button";
+      editBtn.className =
+        "flex-1 py-3 bg-dark-woody text-white text-sm font-bold hover:opacity-90 transition-opacity";
+      editBtn.textContent = "배송정보 수정";
+      editBtn.addEventListener("click", () => {
+        const shippingSection = document.getElementById(
+          "shipping-info-section",
+        );
+        renderShippingForm(
+          order.shippingAddress,
+          shippingSection,
+          async (formData) => {
+            try {
+              await updateOrderShipping(orderId, formData);
+              alert("배송정보가 수정되었습니다.");
+              window.location.reload();
+            } catch (error) {
+              console.error("배송정보 수정 오류:", error);
+              alert("배송정보 수정 중 오류가 발생했습니다.");
+            }
+          },
+        );
+      });
+
+      btnGroup.append(cancelBtn, editBtn);
+      document.querySelector(".max-w-\\[700px\\]").append(btnGroup);
+    }
   } catch (error) {
     console.error("주문 상세 로딩 오류:", error);
   }


### PR DESCRIPTION
## 개요
마이페이지 주문 내역 목록과 주문 상세 페이지를 구현했습니다.

## 작업 내용

### 주문 목록
- 주문 목록 테이블 렌더링 (시맨틱 table 구조 적용)
- 주문 처리 현황 카운트 (전체 주문 기준으로 별도 API 호출)
- 페이지네이션 구현 (createPagination 컴포넌트 재사용)
- 행 클릭 시 주문 상세 페이지 이동

### 주문 상세
- 주문 상태 배지 표시
- PAID 상태일 때만 주문 취소 / 배송정보 수정 버튼 노출
- 주문 취소 모달 (사유 선택 / 기타 직접 입력)
- 배송정보 인라인 수정 폼 (다음 주소 API 연동)
- 뒤로가기 버튼 클릭 시 주문 내역 탭으로 복귀

### 기타
- `fetchAPIWithMeta` 추가 — meta(pagination) 포함 응답이 필요한 경우 사용
- `fetchOrder`에 `page`, `limit` 파라미터 추가
- 마이페이지 진입 시 URL 파라미터(`?menu=order`)로 초기 탭 설정

---

## PR 유형

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [x] refactor: 코드 리팩토링
- [ ] style: 코드 스타일 변경 (UI 포함)
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정
- [ ] chore: 빌드, 설정, 패키지, 파일 구조 변경

---

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #362
