### PR TITLE
feat: 마이페이지 위시리스트 조회 구현

### DIFF
--- a/src/js/api/wishList/index.js
+++ b/src/js/api/wishList/index.js
@@ -8,6 +8,6 @@ export function toggleIsWished(productId) {
 }
 
 //위시리스트 조회
-export function fetchWishList() {
-  return fetchAPI("/members/me/wishlist");
+export function fetchWishList(page = 1, limit = 10) {
+  return fetchAPI(`/members/me/wishlist?page=${page}&limit=${limit}`);
 }

--- a/src/pages/mypage/components/myWishTemplate.js
+++ b/src/pages/mypage/components/myWishTemplate.js
@@ -5,7 +5,7 @@ export function getWishTemplate() {
   <span class="text-[10px] text-empress uppercase tracking-[0.2em]" id="wish-count">-</span>
 </div>
 
-<div id="wish-list-container" class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-x-12 gap-y-20"></div>
+<div id="wish-list-container" class="list-none grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-x-12 gap-y-20"></div>
 
 <div id="wish-empty" class="hidden py-40 text-center">
   <p class="text-[10px] text-empress uppercase tracking-[0.3em] mb-10 italic">Your list is currently empty</p>

--- a/src/pages/mypage/handlers/initMypageEvents.js
+++ b/src/pages/mypage/handlers/initMypageEvents.js
@@ -17,10 +17,23 @@ const RENDER_MAP = {
 };
 
 export function updateSidebarUI(activeMenu) {
+  // 사이드바
   const buttons = document.querySelectorAll("#mypage-nav button[data-menu]");
   buttons.forEach((button) => {
     const isActive = button.dataset.menu === activeMenu;
     button.className = `${BASE_MENU_CLASS} ${isActive ? ACTIVE_MENU_CLASS : INACTIVE_MENU_CLASS}`;
+    button.setAttribute("aria-current", isActive ? "page" : "false");
+  });
+
+  // 모바일 탭
+  const tabBtns = document.querySelectorAll("#mypage-tab button[data-menu]");
+  tabBtns.forEach((button) => {
+    const isActive = button.dataset.menu === activeMenu;
+    button.className = `mypage-tab-btn flex-1 py-3 text-xs border-b-2 transition-colors ${
+      isActive
+        ? "text-ferra font-semibold border-ferra"
+        : "text-empress border-transparent hover:text-dark-woody"
+    }`;
     button.setAttribute("aria-current", isActive ? "page" : "false");
   });
 }
@@ -38,15 +51,29 @@ export async function renderSection(menu) {
 }
 
 export function initMypageEvents() {
+  // 사이드바 네비
   const nav = document.querySelector("#mypage-nav");
-  if (!nav) return;
+  if (nav) {
+    nav.addEventListener("click", async (e) => {
+      const btn = e.target.closest("button[data-menu]");
+      if (!btn) return;
+      const menu = btn.dataset.menu;
+      updateSidebarUI(menu);
+      await renderSection(menu);
+      history.replaceState(null, "", `?menu=${menu}`);
+    });
+  }
 
-  nav.addEventListener("click", async (e) => {
-    const btn = e.target.closest("button[data-menu]");
-    if (!btn) return;
-
-    const menu = btn.dataset.menu;
-    updateSidebarUI(menu);
-    await renderSection(menu);
-  });
+  // 모바일 탭
+  const tab = document.querySelector("#mypage-tab");
+  if (tab) {
+    tab.addEventListener("click", async (e) => {
+      const btn = e.target.closest("button[data-menu]");
+      if (!btn) return;
+      const menu = btn.dataset.menu;
+      updateSidebarUI(menu);
+      await renderSection(menu);
+      history.replaceState(null, "", `?menu=${menu}`);
+    });
+  }
 }

--- a/src/pages/mypage/handlers/renderWishList.js
+++ b/src/pages/mypage/handlers/renderWishList.js
@@ -1,7 +1,134 @@
 import { getWishTemplate } from "/src/pages/mypage/components/myWishTemplate.js";
+import { fetchWishList, toggleIsWished } from "/src/js/api/wishlist/index.js";
 
-export function renderWishList() {
+export async function renderWishList() {
   const container = document.querySelector("#mypage-content");
   if (!container) return;
+
   container.innerHTML = getWishTemplate();
+
+  const wishContainer = document.querySelector("#wish-list-container");
+  const wishEmpty = document.querySelector("#wish-empty");
+  const wishCount = document.querySelector("#wish-count");
+
+  let currentPage = 1;
+  const LIMIT = 10;
+  let total = 0;
+
+  // 더보기 버튼 생성
+  const loadMoreBtn = document.createElement("button");
+  loadMoreBtn.type = "button";
+  loadMoreBtn.className =
+    "mt-16 mx-auto block border border-dark-woody px-12 py-4 text-[10px] uppercase tracking-[0.2em] hover:bg-dark-woody hover:text-white transition-all";
+  loadMoreBtn.textContent = "더보기";
+
+  async function loadItems() {
+    try {
+      const res = await fetchWishList(currentPage, LIMIT);
+      const items = res.items ?? [];
+      total = res.total ?? 0;
+
+      wishCount.textContent = `${total} items`;
+
+      if (total === 0) {
+        wishEmpty.classList.remove("hidden");
+        return;
+      }
+
+      renderItems(items);
+
+      // 더보기 버튼 표시 여부
+      const loaded = wishContainer.querySelectorAll("li").length;
+      if (loaded < total) {
+        wishContainer.after(loadMoreBtn);
+      } else {
+        loadMoreBtn.remove();
+      }
+    } catch (e) {
+      console.error("위시리스트 로딩 오류:", e);
+      wishContainer.innerHTML = `<p class="text-sm text-empress">데이터를 불러오는 중 오류가 발생했습니다.</p>`;
+    }
+  }
+
+  function renderItems(items) {
+    const fragment = document.createDocumentFragment();
+
+    items.forEach((item) => {
+      const li = document.createElement("li");
+
+      const article = document.createElement("article");
+      article.className = "flex flex-col gap-3 group cursor-pointer";
+      article.addEventListener("click", (e) => {
+        if (e.target.closest(".wish-remove-btn")) return;
+        window.location.href = `/src/pages/product/detail/?id=${item.productId}`;
+      });
+
+      const figure = document.createElement("figure");
+      figure.className = "relative overflow-hidden m-0";
+
+      const img = document.createElement("img");
+      img.src = item.thumbnailUrl;
+      img.alt = item.name;
+      img.className = "w-full aspect-[3/4] object-cover bg-cararra";
+
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.className =
+        "wish-remove-btn absolute top-3 right-3 w-8 h-8 flex items-center justify-center bg-white/80 hover:bg-white transition-colors";
+      removeBtn.setAttribute("aria-label", `${item.name} 위시리스트에서 삭제`);
+      removeBtn.textContent = "✕";
+      removeBtn.addEventListener("click", async () => {
+        try {
+          await toggleIsWished(item.productId);
+          li.remove();
+
+          const remaining = wishContainer.querySelectorAll("li").length;
+          total--;
+          wishCount.textContent = `${total} items`;
+
+          if (remaining === 0) {
+            wishEmpty.classList.remove("hidden");
+            loadMoreBtn.remove();
+          }
+        } catch (e) {
+          console.error("위시리스트 삭제 오류:", e);
+        }
+      });
+
+      figure.append(img, removeBtn);
+
+      const info = document.createElement("div");
+      info.className = "flex flex-col gap-1";
+
+      const name = document.createElement("h3");
+      name.className = "text-sm font-medium text-dark-woody leading-snug";
+      name.textContent = item.name;
+
+      const price = document.createElement("p");
+      price.className = "text-sm text-empress";
+      price.textContent = `${item.price.toLocaleString()}원`;
+
+      info.append(name, price);
+
+      if (!item.isInStock) {
+        const soldOut = document.createElement("p");
+        soldOut.className = "text-[10px] text-ferra uppercase tracking-widest";
+        soldOut.textContent = "품절";
+        info.append(soldOut);
+      }
+
+      article.append(figure, info);
+      li.append(article);
+      fragment.appendChild(li);
+    });
+
+    wishContainer.appendChild(fragment);
+  }
+
+  loadMoreBtn.addEventListener("click", () => {
+    currentPage++;
+    loadItems();
+  });
+
+  loadItems();
 }

--- a/src/pages/mypage/index.html
+++ b/src/pages/mypage/index.html
@@ -10,9 +10,44 @@
   <body class="bg-white-solid text-dark-woody">
     <header id="header"></header>
 
-    <main class="max-w-[1280px] mx-auto w-full px-4 py-10 sm:px-6 lg:px-10 lg:py-20 flex flex-col lg:flex-row gap-8 lg:gap-20">
-      <aside class="w-full lg:w-56 lg:flex-shrink-0">
-        <h2 class="text-2xl md:text-3xl font-light tracking-tighter mb-8 md:mb-12">마이 페이지</h2>
+    <main
+      class="max-w-[1280px] min-w-[400px] mx-auto w-full px-4 py-10 sm:px-6 lg:px-10 lg:py-20 flex flex-col lg:flex-row gap-8 lg:gap-20"
+    >
+      <!-- 모바일 탭: lg 미만에서만 표시 -->
+      <nav id="mypage-tab" class="flex border-b border-cararra lg:hidden">
+        <button
+          data-menu="info"
+          class="mypage-tab-btn flex-1 py-3 text-xs text-empress border-b-2 border-transparent transition-colors hover:text-dark-woody"
+        >
+          내 정보
+        </button>
+        <button
+          data-menu="order"
+          class="mypage-tab-btn flex-1 py-3 text-xs text-empress border-b-2 border-transparent transition-colors hover:text-dark-woody"
+        >
+          주문 내역
+        </button>
+        <button
+          data-menu="wish"
+          class="mypage-tab-btn flex-1 py-3 text-xs text-empress border-b-2 border-transparent transition-colors hover:text-dark-woody"
+        >
+          위시리스트
+        </button>
+        <button
+          data-menu="review"
+          class="mypage-tab-btn flex-1 py-3 text-xs text-empress border-b-2 border-transparent transition-colors hover:text-dark-woody"
+        >
+          내 리뷰
+        </button>
+      </nav>
+
+      <!-- 사이드바: lg 이상에서만 표시 -->
+      <aside class="w-full lg:w-56 lg:flex-shrink-0 hidden lg:block">
+        <h2
+          class="text-2xl md:text-3xl font-light tracking-tighter mb-8 md:mb-12"
+        >
+          마이 페이지
+        </h2>
 
         <nav id="mypage-nav" class="flex flex-col gap-2">
           <button
@@ -29,7 +64,6 @@
               <path d="M9 5l7 7-7 7"></path>
             </svg>
           </button>
-
           <button
             data-menu="order"
             class="group w-full flex items-center justify-between py-3 text-sm border-b transition-colors text-empress border-cararra/30 hover:text-dark-woody"
@@ -44,7 +78,6 @@
               <path d="M9 5l7 7-7 7"></path>
             </svg>
           </button>
-
           <button
             data-menu="wish"
             class="group w-full flex items-center justify-between py-3 text-sm border-b transition-colors text-empress border-cararra/30 hover:text-dark-woody"
@@ -59,7 +92,6 @@
               <path d="M9 5l7 7-7 7"></path>
             </svg>
           </button>
-
           <button
             data-menu="review"
             class="group w-full flex items-center justify-between py-3 text-sm border-b transition-colors text-empress border-cararra/30 hover:text-dark-woody"


### PR DESCRIPTION
## 개요
마이페이지 위시리스트 조회 기능을 구현했습니다.

## 작업 내용

### 위시리스트
- 위시리스트 목록 렌더링
- 더보기 버튼으로 추가 상품 로드 (페이지당 10개)
- 위시리스트 삭제 (toggleIsWished 연동)
- 품절 상태 표시
- 반응형 그리드 (767 이하 2열 / 768~1023 3열 / 1024 이상 4열)

### 반응형 개선
- 1024 미만에서 사이드바 대신 상단 탭 메뉴 표시
- 최소 너비 400px 유지
- 메뉴 클릭 시 URL 파라미터 업데이트 (새로고침 시 현재 탭 유지)


---

## PR 유형

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] style: 코드 스타일 변경 (UI 포함)
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정
- [ ] chore: 빌드, 설정, 패키지, 파일 구조 변경

---

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #366
