### PR TITLE
fix: 모바일 상품 상세 이미지 슬라이더 빈 화면 및 이미지 위치 오류 수정 (#417)

### DIFF
--- a/src/pages/product/detail/components/getMainTemplate.js
+++ b/src/pages/product/detail/components/getMainTemplate.js
@@ -12,7 +12,7 @@ export function getMainTemplate() {
     <div class="lg:hidden relative overflow-hidden w-full h-[420px] sm:h-[520px]">
       <div
         id="slider-track"
-        class="flex transition-transform duration-300 ease-in-out"
+        class="flex transition-transform duration-300 ease-in-out h-full w-full"
       ></div>
       <button
         id="slider-prev"

--- a/src/pages/product/detail/handlers/renderProductMain.js
+++ b/src/pages/product/detail/handlers/renderProductMain.js
@@ -56,8 +56,7 @@ export function renderProductMain(product) {
 
   allImages.forEach((src, i) => {
     const slide = document.createElement("div");
-    slide.className =
-      "min-w-full overflow-hidden flex-shrink-0 h-[420px] sm:h-[520px]";
+    slide.className = "min-w-full overflow-hidden flex-shrink-0 h-full";
 
     const img = document.createElement("img");
     img.className = "bg-merino w-full h-full object-contain";


### PR DESCRIPTION
## 📌 작업 내용

- slider-track에 h-full, w-full 추가하여 wrapper 높이 상속
- 슬라이드 높이를 h-[420px]에서 h-full로 변경하여 wrapper에서 일괄 관리

---

## PR 유형

- [ ] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] style: 코드 스타일 변경 (UI 포함)
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정
- [ ] chore: 빌드, 설정, 패키지, 파일 구조 변경

---

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #
